### PR TITLE
Support multilingual module title/description DTOs and preserve locales in Module DTOs

### DIFF
--- a/src/modules/common/types/content.ts
+++ b/src/modules/common/types/content.ts
@@ -1,4 +1,5 @@
 // src/common/types/content.ts
+import { MultilingualText, OptionalMultilingualText } from '../utils/i18n.util';
 export type CEFR = 'A0'|'A1'|'A2'|'B1'|'B2'|'C1'|'C2';
 
 export interface ModuleProgress {
@@ -10,8 +11,8 @@ export interface ModuleProgress {
 export interface ModuleItem {
   moduleRef: string;
   level: CEFR;
-  title: string;              // Простой string как «presented» поле; хранить можно мультиязычно
-  description?: string;
+  title: MultilingualText;
+  description?: OptionalMultilingualText;
   tags: string[];
   order: number;
   requiresPro: boolean;

--- a/src/modules/common/utils/mappers.ts
+++ b/src/modules/common/utils/mappers.ts
@@ -20,15 +20,13 @@ const redact = (v: any): any =>
 export class ModuleMapper {
   static toDto(
     module: CourseModule,
-    userId: string,
-    language: SupportedLanguage = 'ru',
     progress?: { completed: number; total: number; inProgress: number }
   ): ModuleItem {
     return {
       moduleRef: module.moduleRef,
       level: module.level,
-      title: getLocalizedText(module.title, language),
-      description: getLocalizedText(module.description, language),
+      title: module.title,
+      description: module.description,
       tags: module.tags || [],
       order: module.order || 0,
       requiresPro: module.requiresPro || false,

--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -27,7 +27,7 @@ export class ContentV2Controller {
       return { error: 'userId is required' };
     }
 
-    const { level, lang = 'ru', page = 1, limit = 20 } = query;
+    const { level, page = 1, limit = 20 } = query;
     
     // Валидация level
     if (level && !['A0', 'A1', 'A2', 'B1', 'B2', 'C1', 'C2'].includes(level)) {
@@ -93,7 +93,7 @@ export class ContentV2Controller {
         isAvailable,
       };
       
-      return presentModule(moduleData as any, lang, { completed: pr.completed, inProgress: pr.inProgress, total });
+      return presentModule(moduleData as any, { completed: pr.completed, inProgress: pr.inProgress, total });
     });
 
     return {

--- a/src/modules/content/content.controller.ts
+++ b/src/modules/content/content.controller.ts
@@ -30,9 +30,8 @@ export class ContentController {
   @Get('modules')
   @UseGuards(JwtAuthGuard)
   async getModules(@Query() query: GetModulesDto, @Request() req: any) {
-    const { level, lang } = query;
+    const { level } = query;
     const userId = req.user?.userId; // Get userId from JWT token
-    const language = parseLanguage(lang);
     const filter: any = { published: true };
     if (level) filter.level = level;
 
@@ -74,7 +73,7 @@ export class ContentController {
           const requiresPro = m.requiresPro || order > 1; // Use schema field or business rule
           const isAvailable = m.isAvailable ?? (!requiresPro || hasProAccess);
 
-          return ModuleMapper.toDto(m, String(userId), language, progressMap.get(m.moduleRef));
+          return ModuleMapper.toDto(m, progressMap.get(m.moduleRef));
         }),
       };
     }
@@ -86,7 +85,7 @@ export class ContentController {
         const requiresPro = m.requiresPro || order > 1;
         const isAvailable = m.isAvailable ?? !requiresPro; // Anonymous user never has pro access
         
-        return ModuleMapper.toDto(m, '', language, undefined);
+        return ModuleMapper.toDto(m);
       }),
     };
   }
@@ -351,5 +350,3 @@ export class ContentController {
     };
   }
 }
-
-

--- a/src/modules/content/content.service.ts
+++ b/src/modules/content/content.service.ts
@@ -4,6 +4,7 @@ import { Model } from 'mongoose';
 import { CourseModule, CourseModuleDocument } from '../common/schemas/course-module.schema';
 import { Lesson, LessonDocument } from '../common/schemas/lesson.schema';
 import { UserLessonProgress, UserLessonProgressDocument } from '../common/schemas/user-lesson-progress.schema';
+import { MultilingualText, OptionalMultilingualText } from '../common/utils/i18n.util';
 
 @Injectable()
 export class ContentService {
@@ -14,7 +15,7 @@ export class ContentService {
   ) {}
 
   // Modules
-  async createModule(body: { moduleRef: string; level: CourseModule['level']; title: string; description?: string; tags?: string[]; order?: number; published?: boolean }) {
+  async createModule(body: { moduleRef: string; level: CourseModule['level']; title: MultilingualText; description?: OptionalMultilingualText; tags?: string[]; order?: number; published?: boolean }) {
     return this.moduleModel.create(body);
   }
 
@@ -90,5 +91,4 @@ export class ContentService {
     return { canStart: true };
   }
 }
-
 

--- a/src/modules/content/dto/module.dto.ts
+++ b/src/modules/content/dto/module.dto.ts
@@ -1,5 +1,24 @@
-import { IsArray, IsBoolean, IsInt, IsOptional, IsString, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsInt, IsObject, IsOptional, IsString, Min, ValidateNested } from 'class-validator';
 export type CEFR = 'A0'|'A1'|'A2'|'B1'|'B2'|'C1'|'C2';
+
+export class MultilingualTextDto {
+  @IsString()
+  ru!: string;
+
+  @IsString()
+  en!: string;
+}
+
+export class OptionalMultilingualTextDto {
+  @IsOptional()
+  @IsString()
+  ru?: string;
+
+  @IsOptional()
+  @IsString()
+  en?: string;
+}
 
 export class CreateModuleDto {
   @IsString()
@@ -8,12 +27,16 @@ export class CreateModuleDto {
   @IsString()
   level!: CEFR;
 
-  @IsString()
-  title!: string;
+  @IsObject()
+  @ValidateNested()
+  @Type(() => MultilingualTextDto)
+  title!: MultilingualTextDto;
 
   @IsOptional()
-  @IsString()
-  description?: string;
+  @IsObject()
+  @ValidateNested()
+  @Type(() => OptionalMultilingualTextDto)
+  description?: OptionalMultilingualTextDto;
 
   @IsOptional()
   @IsArray()
@@ -38,5 +61,4 @@ export class CreateModuleDto {
 }
 
 export class UpdateModuleDto extends CreateModuleDto {}
-
 

--- a/src/modules/content/presenter.ts
+++ b/src/modules/content/presenter.ts
@@ -12,14 +12,13 @@ const choose = (mt: any, lang: string) => {
 
 export function presentModule(
   doc: CourseModule,
-  lang = 'ru',
   progress?: { completed: number; total: number; inProgress: number },
 ): ModuleItem {
   return {
     moduleRef: doc.moduleRef,
     level: doc.level,
-    title: choose(doc.title, lang),
-    description: choose(doc.description, lang),
+    title: doc.title,
+    description: doc.description,
     tags: doc.tags || [],
     order: doc.order ?? 0,
     // Используем переданные значения, если они есть, иначе вычисляем из схемы


### PR DESCRIPTION
### Motivation

- Introduce structured multilingual fields for module `title`/`description` so both `ru` and `en` can be provided and validated.
- Add nested validation to avoid losing structure when creating/updating modules.
- Ensure API responses can expose both locales (structured object) instead of always returning a single localized string.
- Keep service and presenter logic compatible with the new nested multilingual format.

### Description

- Updated DTOs to validate nested multilingual objects in `src/modules/content/dto/module.dto.ts` by adding `MultilingualTextDto`/`OptionalMultilingualTextDto` and applying `@IsObject`, `@ValidateNested`, and `@Type` annotations.
- Changed `ModuleItem` types to use `MultilingualText`/`OptionalMultilingualText` in `src/modules/common/types/content.ts` so DTOs carry both locales.
- Modified `ModuleMapper.toDto` and related mapping logic in `src/modules/common/utils/mappers.ts` to return the multilingual objects (`title`/`description`) directly instead of pre-selecting a language.
- Adjusted `presentModule`, `ContentController`, `ContentV2Controller`, and `ContentService` signatures/usages to accept and propagate the structured multilingual fields (files: `src/modules/content/presenter.ts`, `src/modules/content/content.controller.ts`, `src/modules/content/content-v2.controller.ts`, `src/modules/content/content.service.ts`).

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950265c4b64832099c43e776942df65)