### PR TITLE
Add difficultyRating support for course modules

### DIFF
--- a/src/modules/common/schemas/course-module.schema.ts
+++ b/src/modules/common/schemas/course-module.schema.ts
@@ -21,6 +21,9 @@ export class CourseModule {
   @Prop({ type: [String], default: [] })
   tags?: string[]; // e.g., travel, speaking
 
+  @Prop({ min: 1, max: 5 })
+  difficultyRating?: number;
+
   @Prop({ default: true })
   published?: boolean;
 
@@ -36,5 +39,4 @@ export class CourseModule {
 
 export const CourseModuleSchema = SchemaFactory.createForClass(CourseModule);
 CourseModuleSchema.index({ level: 1, order: 1 });
-
 

--- a/src/modules/common/types/content.ts
+++ b/src/modules/common/types/content.ts
@@ -14,6 +14,7 @@ export interface ModuleItem {
   title: MultilingualText;
   description?: OptionalMultilingualText;
   tags: string[];
+  difficultyRating?: number;
   order: number;
   requiresPro: boolean;
   isAvailable: boolean;

--- a/src/modules/common/utils/mappers.ts
+++ b/src/modules/common/utils/mappers.ts
@@ -28,6 +28,7 @@ export class ModuleMapper {
       title: module.title,
       description: module.description,
       tags: module.tags || [],
+      difficultyRating: module.difficultyRating,
       order: module.order || 0,
       requiresPro: module.requiresPro || false,
       isAvailable: module.isAvailable ?? true,

--- a/src/modules/content/dto/module.dto.ts
+++ b/src/modules/content/dto/module.dto.ts
@@ -1,6 +1,33 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsInt, IsObject, IsOptional, IsString, Min, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsInt, IsNumber, IsObject, IsOptional, IsString, Max, Min, ValidateNested, registerDecorator, ValidationArguments, ValidationOptions } from 'class-validator';
 export type CEFR = 'A0'|'A1'|'A2'|'B1'|'B2'|'C1'|'C2';
+
+const isHalfStep = (value: number): boolean => Number.isInteger(value * 2);
+
+const IsHalfStep = (validationOptions?: ValidationOptions) => (object: object, propertyName: string) => {
+  registerDecorator({
+    name: 'isHalfStep',
+    target: object.constructor,
+    propertyName,
+    options: validationOptions,
+    validator: {
+      validate(value: number | undefined, _args: ValidationArguments) {
+        if (value === undefined || value === null) {
+          return true;
+        }
+
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+          return false;
+        }
+
+        return isHalfStep(value);
+      },
+      defaultMessage(args: ValidationArguments) {
+        return `${args.property} must be in increments of 0.5`;
+      }
+    }
+  });
+};
 
 export class MultilingualTextDto {
   @IsString()
@@ -43,6 +70,13 @@ export class CreateModuleDto {
   tags?: string[];
 
   @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(5)
+  @IsHalfStep()
+  difficultyRating?: number;
+
+  @IsOptional()
   @IsInt()
   @Min(0)
   order?: number;
@@ -61,4 +95,3 @@ export class CreateModuleDto {
 }
 
 export class UpdateModuleDto extends CreateModuleDto {}
-


### PR DESCRIPTION
### Motivation
- Add a numeric difficulty rating for course modules to provide a simple module-level difficulty signal in the range 1–5 with 0.5 increments.  
- Ensure the new field is validated at DTO boundary and constrained in the database schema.  
- Expose the value through the existing content types and mappers so it is returned to clients.  

### Description
- Add `difficultyRating?: number` to the `CourseModule` Mongoose schema with `min: 1` and `max: 5` via `@Prop`.  
- Add `difficultyRating?: number` to `CreateModuleDto` with validation using `@IsNumber()`, `@Min(1)`, `@Max(5)` and a custom `IsHalfStep` decorator (implemented with `registerDecorator`) that enforces 0.5 increments.  
- Extend the `ModuleItem` type with `difficultyRating?: number` in `src/modules/common/types/content.ts`.  
- Include `difficultyRating` in `ModuleMapper.toDto` so mapped DTOs include the new field.  

### Testing
- No automated tests were executed for this change.  
- Type checking and runtime validation were not run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695027b0c3bc8320b6aa3f34e758cde2)