### PR TITLE
Add author metadata to course modules and record author on creation

### DIFF
--- a/src/modules/common/schemas/course-module.schema.ts
+++ b/src/modules/common/schemas/course-module.schema.ts
@@ -35,8 +35,13 @@ export class CourseModule {
 
   @Prop({ default: true })
   isAvailable?: boolean;
+
+  @Prop({ type: Object })
+  author?: {
+    userId: string;
+    name?: string;
+  };
 }
 
 export const CourseModuleSchema = SchemaFactory.createForClass(CourseModule);
 CourseModuleSchema.index({ level: 1, order: 1 });
-

--- a/src/modules/common/types/content.ts
+++ b/src/modules/common/types/content.ts
@@ -18,6 +18,10 @@ export interface ModuleItem {
   order: number;
   requiresPro: boolean;
   isAvailable: boolean;
+  author?: {
+    userId: string;
+    name?: string;
+  };
   progress?: ModuleProgress;  // вычисляется для текущего userId
 }
 

--- a/src/modules/common/utils/mappers.ts
+++ b/src/modules/common/utils/mappers.ts
@@ -32,6 +32,7 @@ export class ModuleMapper {
       order: module.order || 0,
       requiresPro: module.requiresPro || false,
       isAvailable: module.isAvailable ?? true,
+      author: module.author,
       progress: progress || { completed: 0, total: 0, inProgress: 0 }
     };
   }

--- a/src/modules/content/admin-content.controller.ts
+++ b/src/modules/content/admin-content.controller.ts
@@ -14,8 +14,12 @@ export class AdminContentController {
   // Modules
   @Post('modules')
   async createModule(@Body() body: CreateModuleDto, @Request() req: any) {
+    const user = req.user?.user;
     const userId = req.user?.userId; // Get userId from JWT token
-    const doc = await this.content.createModule(body as any);
+    const nameParts = [user?.firstName, user?.lastName].filter(Boolean);
+    const authorName = nameParts.length ? nameParts.join(' ') : user?.username;
+    const author = userId ? { userId, name: authorName } : undefined;
+    const doc = await this.content.createModule({ ...(body as any), author });
     return { id: (doc as any)._id };
   }
 
@@ -59,5 +63,4 @@ export class AdminContentController {
     return this.content.updateLesson(lessonRef, body as any);
   }
 }
-
 

--- a/src/modules/content/content.service.ts
+++ b/src/modules/content/content.service.ts
@@ -15,7 +15,7 @@ export class ContentService {
   ) {}
 
   // Modules
-  async createModule(body: { moduleRef: string; level: CourseModule['level']; title: MultilingualText; description?: OptionalMultilingualText; tags?: string[]; order?: number; published?: boolean }) {
+  async createModule(body: { moduleRef: string; level: CourseModule['level']; title: MultilingualText; description?: OptionalMultilingualText; tags?: string[]; order?: number; published?: boolean; author?: CourseModule['author'] }) {
     return this.moduleModel.create(body);
   }
 
@@ -26,7 +26,8 @@ export class ContentService {
   }
 
   async updateModule(moduleRef: string, update: Partial<CourseModule>) {
-    await this.moduleModel.updateOne({ moduleRef }, { $set: update });
+    const { author, ...safeUpdate } = update;
+    await this.moduleModel.updateOne({ moduleRef }, { $set: safeUpdate });
     return { ok: true };
   }
 
@@ -91,4 +92,3 @@ export class ContentService {
     return { canStart: true };
   }
 }
-


### PR DESCRIPTION
### Motivation
- Track the creator/owner of course modules so clients and admins can see who authored a module.
- Ensure the author is recorded from the authenticated request when an admin creates a module via the admin API.
- Prevent accidental or malicious overwriting of the stored author during module updates.
- Expose the author information in API DTOs so it can be returned to clients when appropriate.

### Description
- Added an `author` field to the `CourseModule` schema (`src/modules/common/schemas/course-module.schema.ts`) with `userId` and optional `name`.
- Extended `ContentService.createModule` to accept an `author` in the payload and changed `updateModule` to strip `author` from updates so it cannot be modified.
- Updated `AdminContentController.createModule` to derive `author` from `req.user` (using `userId`, `firstName`, `lastName`, or `username`) and pass it to `createModule`.
- Added `author` to the `ModuleItem` type in `src/modules/common/types/content.ts` and included `author` in the `ModuleMapper.toDto` output in `src/modules/common/utils/mappers.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695028a19b38832093da83e970f70d84)