### PR TITLE
Raise Nest exceptions in ContentController and update tests

### DIFF
--- a/src/modules/content/__tests__/content.controller.spec.ts
+++ b/src/modules/content/__tests__/content.controller.spec.ts
@@ -1,0 +1,166 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ExecutionContext } from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import * as request from 'supertest';
+import { ContentController } from '../content.controller';
+import { ContentService } from '../content.service';
+import { VocabularyService } from '../vocabulary.service';
+import { OptionalUserGuard } from '../../common/guards/optional-user.guard';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
+import { LessonPrerequisiteGuard } from '../guards/lesson-prerequisite.guard';
+import { CourseModule } from '../../common/schemas/course-module.schema';
+import { Lesson } from '../../common/schemas/lesson.schema';
+import { User } from '../../common/schemas/user.schema';
+import { UserLessonProgress } from '../../common/schemas/user-lesson-progress.schema';
+
+describe('ContentController', () => {
+  let app: INestApplication;
+  let currentMockUser: Record<string, any> | undefined;
+
+  const mockUserModel = {
+    findOne: jest.fn(),
+  };
+
+  const mockModuleModel = {
+    find: jest.fn(),
+  };
+
+  const mockLessonModel = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const mockUlpModel = {
+    find: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const mockContentService = {
+    canStartLesson: jest.fn(),
+  };
+
+  const mockVocabularyService = {
+    getModuleVocabulary: jest.fn(),
+    getVocabularyProgressStats: jest.fn(),
+  };
+
+  const mockJwtAuthGuard = {
+    canActivate: (context: ExecutionContext) => {
+      const req = context.switchToHttp().getRequest();
+      req.user = currentMockUser;
+      return true;
+    },
+  };
+
+  beforeEach(async () => {
+    currentMockUser = { userId: 'user-123' };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [ContentController],
+      providers: [
+        {
+          provide: getModelToken(User.name),
+          useValue: mockUserModel,
+        },
+        {
+          provide: getModelToken(CourseModule.name),
+          useValue: mockModuleModel,
+        },
+        {
+          provide: getModelToken(Lesson.name),
+          useValue: mockLessonModel,
+        },
+        {
+          provide: getModelToken(UserLessonProgress.name),
+          useValue: mockUlpModel,
+        },
+        {
+          provide: ContentService,
+          useValue: mockContentService,
+        },
+        {
+          provide: VocabularyService,
+          useValue: mockVocabularyService,
+        },
+      ],
+    })
+      .overrideGuard(OptionalUserGuard)
+      .useValue(mockJwtAuthGuard)
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
+      .overrideGuard(LessonPrerequisiteGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('GET /content/lessons', () => {
+    it('should return 400 with Nest error body for invalid moduleRef', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/content/lessons')
+        .query({ moduleRef: 'invalid-module-ref' })
+        .expect(400);
+
+      expect(response.body).toEqual({
+        statusCode: 400,
+        message: 'Invalid moduleRef format',
+        error: 'Bad Request',
+      });
+    });
+  });
+
+  describe('GET /content/lessons/:lessonRef', () => {
+    it('should return 400 with Nest error body for invalid lessonRef', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/content/lessons/invalid-lesson-ref')
+        .expect(400);
+
+      expect(response.body).toEqual({
+        statusCode: 400,
+        message: 'Invalid lessonRef format',
+        error: 'Bad Request',
+      });
+    });
+
+    it('should return 404 with Nest error body when lesson is not found', async () => {
+      mockLessonModel.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/content/lessons/a1.module_1.001')
+        .expect(404);
+
+      expect(response.body).toEqual({
+        statusCode: 404,
+        message: 'Lesson not found',
+        error: 'Not Found',
+      });
+    });
+  });
+
+  describe('GET /content/lessons/:lessonRef/check-prerequisite', () => {
+    it('should return 400 with Nest error body when userId is missing', async () => {
+      currentMockUser = {};
+
+      const response = await request(app.getHttpServer())
+        .get('/content/lessons/a1.module_1.001/check-prerequisite')
+        .expect(400);
+
+      expect(response.body).toEqual({
+        statusCode: 400,
+        message: 'userId is required',
+        error: 'Bad Request',
+      });
+      expect(mockContentService.canStartLesson).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/content/content.controller.ts
+++ b/src/modules/content/content.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, Param, Query, UseGuards, Request } from '@nestjs/common';
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -100,7 +109,7 @@ export class ContentController {
     if (moduleRef) {
       // 🔒 БАЗОВАЯ ВАЛИДАЦИЯ moduleRef
       if (!/^[a-z0-9]+\.[a-z0-9_]+$/.test(moduleRef)) {
-        return { error: 'Invalid moduleRef format' };
+        throw new BadRequestException('Invalid moduleRef format');
       }
       filter.moduleRef = moduleRef;
     }
@@ -148,12 +157,12 @@ export class ContentController {
 
     // 🔒 БАЗОВАЯ ВАЛИДАЦИЯ lessonRef
     if (!/^[a-z0-9]+\.[a-z0-9_]+\.\d{3}$/.test(lessonRef)) {
-      return { error: 'Invalid lessonRef format' };
+      throw new BadRequestException('Invalid lessonRef format');
     }
 
     const lesson = await this.lessonModel.findOne({ lessonRef, published: true }).lean();
     if (!lesson) {
-      return { error: 'Lesson not found' };
+      throw new NotFoundException('Lesson not found');
     }
 
     let progress = null;
@@ -183,7 +192,7 @@ export class ContentController {
     const userId = req.user?.userId; // Get userId from JWT token
     
     if (!userId) {
-      return { error: 'userId is required' };
+      throw new BadRequestException('userId is required');
     }
 
     const result = await this.contentService.canStartLesson(userId, lessonRef);


### PR DESCRIPTION
### Motivation

- Replace ad-hoc error responses with framework exceptions to ensure consistent HTTP codes and Nest error bodies for invalid inputs and missing data. 
- Make controller behavior align with API expectations for client error handling and middleware. 

### Description

- Import and throw `BadRequestException` and `NotFoundException` in `ContentController` and replace `return { error: ... }` with `throw` for validation failures in `getLessons`, `getLesson`, and `checkLessonPrerequisite`.
- Specifically change `getLessons` to `throw new BadRequestException('Invalid moduleRef format')` for invalid `moduleRef` formats.
- Change `getLesson` to `throw new BadRequestException('Invalid lessonRef format')` for invalid `lessonRef` and `throw new NotFoundException('Lesson not found')` when the lesson is missing.
- Add `src/modules/content/__tests__/content.controller.spec.ts` with tests that assert `400`/`404` responses and standard Nest error bodies for these cases.

### Testing

- Added controller tests in `src/modules/content/__tests__/content.controller.spec.ts` that verify error status codes and Nest error response bodies for the modified endpoints.
- No automated test suite was executed as part of this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695098678d7883208d640711fb9194cd)