### PR TITLE
Throw BadRequestException for lesson lint failures

### DIFF
--- a/src/modules/content/__tests__/admin-content.controller.spec.ts
+++ b/src/modules/content/__tests__/admin-content.controller.spec.ts
@@ -494,9 +494,9 @@ describe('AdminContentController', () => {
             },
           ],
         })
-        .expect(201);
+        .expect(400);
 
-      expect(response.body.ok).toBe(false);
+      expect(response.body.message).toBe('Lesson tasks validation failed');
       expect(response.body.errors).toEqual(
         expect.arrayContaining([
           'duplicate task.ref: wrong-prefix.t1',
@@ -536,9 +536,9 @@ describe('AdminContentController', () => {
             },
           ],
         })
-        .expect(200);
+        .expect(400);
 
-      expect(response.body.ok).toBe(false);
+      expect(response.body.message).toBe('Lesson tasks validation failed');
       expect(response.body.errors).toEqual(
         expect.arrayContaining([
           'task[0].ref must start with a0.basics.001.',

--- a/src/modules/content/admin-content.controller.ts
+++ b/src/modules/content/admin-content.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Patch, Post, Query, UseGuards, Request } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Param, Patch, Post, Query, UseGuards, Request } from '@nestjs/common';
 import { ContentService } from './content.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
@@ -41,7 +41,7 @@ export class AdminContentController {
     const userId = req.user?.userId; // Get userId from JWT token
     const errors = lintLessonTasks(body.lessonRef, body.tasks);
     if (errors.length) {
-      return { ok: false, errors };
+      throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }
     const doc = await this.content.createLesson(body as any);
     return { id: (doc as any)._id };
@@ -58,9 +58,8 @@ export class AdminContentController {
     const userId = req.user?.userId; // Get userId from JWT token
     const errors = lintLessonTasks(lessonRef, body.tasks);
     if (errors.length) {
-      return { ok: false, errors };
+      throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }
     return this.content.updateLesson(lessonRef, body as any);
   }
 }
-


### PR DESCRIPTION
### Motivation
- Ensure invalid lesson task data surfaces as an HTTP 400 error instead of a successful 200 payload to follow standard error handling.
- Provide clients with structured validation details via the `message` and `errors` fields when linting fails.
- Make controller behavior consistent with other controllers that throw `BadRequestException` for invalid input.

### Description
- Import and use `BadRequestException` in `src/modules/content/admin-content.controller.ts` and throw `new BadRequestException({ message: 'Lesson tasks validation failed', errors })` when `lintLessonTasks` returns errors in both `createLesson` and `updateLesson` handlers.
- Update `src/modules/content/__tests__/admin-content.controller.spec.ts` to expect `400` responses and to assert `response.body.message` equals `'Lesson tasks validation failed'` and that `response.body.errors` contains the lint messages.
- No other business logic or service calls were changed.

### Testing
- Unit tests in `src/modules/content/__tests__/admin-content.controller.spec.ts` were updated to reflect the new 400 error behavior and assertions for `message`/`errors`.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950aab367d88320ba0560845ad5cb47)