### PR TITLE
Throw NotFoundException for missing lessons and add 404 test

### DIFF
--- a/src/modules/content/__tests__/content-v2.controller.spec.ts
+++ b/src/modules/content/__tests__/content-v2.controller.spec.ts
@@ -164,5 +164,22 @@ describe('ContentV2Controller', () => {
         })
       );
     });
+
+    it('should return 404 for missing lesson', async () => {
+      mockLessonModel.findOne.mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/content/v2/lessons/missing.lesson?lang=ru')
+        .expect(404);
+
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          statusCode: 404,
+          message: 'Lesson not found',
+        })
+      );
+    });
   });
 });

--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -1,5 +1,5 @@
 // src/content/content-v2.controller.ts
-import { Controller, Get, Param, Query, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards, Request, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CourseModule, CourseModuleDocument } from '../common/schemas/course-module.schema';
@@ -131,7 +131,9 @@ export class ContentV2Controller {
     }
 
     const l = await this.lessonModel.findOne({ lessonRef, published: true }).lean();
-    if (!l) return null;
+    if (!l) {
+      throw new NotFoundException('Lesson not found');
+    }
     const p = await this.progressModel.findOne({ userId: String(userId), lessonRef }).lean();
     // detailed: вернём ещё tasks
     const presented = presentLesson(l as any, lang, p as any);


### PR DESCRIPTION
### Motivation

- Make the controller return a proper HTTP 404 error instead of `null` when a lesson is not found to improve API correctness and client handling.
- Ensure behavior is explicitly tested so regressions do not reintroduce the `null` response. 

### Description

- Import `NotFoundException` and replace `if (!l) return null;` with `throw new NotFoundException('Lesson not found')` in `src/modules/content/content-v2.controller.ts`.
- Add a unit test in `src/modules/content/__tests__/content-v2.controller.spec.ts` that requests a missing lesson and expects a 404 with message `Lesson not found`.
- Updated files: `src/modules/content/content-v2.controller.ts` and `src/modules/content/__tests__/content-v2.controller.spec.ts`.

### Testing

- Added an automated unit test in `src/modules/content/__tests__/content-v2.controller.spec.ts` that asserts a 404 for a non-existent `lessonRef`.
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950ab4c4ea88320a55b0e571c79fd37)