### PR TITLE
Use multilingual DTOs for lesson title/description and tighten i18n validation

### DIFF
--- a/src/modules/common/utils/i18n.util.ts
+++ b/src/modules/common/utils/i18n.util.ts
@@ -72,7 +72,14 @@ export function validateMultilingualText(
     return false;
   }
 
-  return requiredLangs.every(lang => textObj[lang] && textObj[lang].trim().length > 0);
+  return requiredLangs.every(lang => {
+    if (!Object.prototype.hasOwnProperty.call(textObj, lang)) {
+      return false;
+    }
+
+    const value = textObj[lang];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
 }
 
 /**

--- a/src/modules/content/__tests__/lesson.dto.spec.ts
+++ b/src/modules/content/__tests__/lesson.dto.spec.ts
@@ -5,7 +5,10 @@ import { CreateLessonDto } from '../dto/lesson.dto';
 const validLesson = {
   moduleRef: 'a0.basics',
   lessonRef: 'a0.basics.001',
-  title: 'Lesson 1',
+  title: {
+    ru: 'Урок 1',
+    en: 'Lesson 1',
+  },
   estimatedMinutes: 5,
   tasks: [
     {
@@ -30,6 +33,17 @@ describe('CreateLessonDto', () => {
 
     expect(errors.some(e => e.property === 'lessonRef')).toBe(true);
     expect(errors.some(e => e.property === 'title')).toBe(true);
+  });
+
+  it('should fail when multilingual title is missing locales', async () => {
+    const dto = plainToInstance(CreateLessonDto, {
+      ...validLesson,
+      title: { ru: 'Только русский' },
+    });
+    const errors = await validate(dto);
+
+    const titleError = errors.find(e => e.property === 'title');
+    expect(titleError?.children?.some(child => child.property === 'en')).toBe(true);
   });
 
   it('should validate estimatedMinutes min value', async () => {

--- a/src/modules/content/dto/lesson.dto.ts
+++ b/src/modules/content/dto/lesson.dto.ts
@@ -1,7 +1,8 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsEnum, IsInt, IsOptional, IsString, Min, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsInt, IsObject, IsOptional, IsString, Min, ValidateNested } from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
 import { TaskDto } from './task-data.dto';
+import { MultilingualTextDto, OptionalMultilingualTextDto } from './module.dto';
 
 export class CreateLessonDto {
   @IsString()
@@ -10,11 +11,16 @@ export class CreateLessonDto {
   @IsString()
   lessonRef!: string;
 
-  @IsString()
-  title!: string;
+  @IsObject()
+  @ValidateNested()
+  @Type(() => MultilingualTextDto)
+  title!: MultilingualTextDto;
 
-  @IsOptional() @IsString()
-  description?: string;
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => OptionalMultilingualTextDto)
+  description?: OptionalMultilingualTextDto;
 
   @IsOptional() @IsInt() @Min(1)
   estimatedMinutes?: number;
@@ -54,5 +60,4 @@ export class CreateLessonDto {
 }
 
 export class UpdateLessonDto extends PartialType(CreateLessonDto) {}
-
 

--- a/src/modules/content/presenter.ts
+++ b/src/modules/content/presenter.ts
@@ -3,12 +3,12 @@ import { Lesson, LessonDocument } from '../common/schemas/lesson.schema';
 import { CourseModule } from '../common/schemas/course-module.schema';
 import { UserLessonProgress } from '../common/schemas/user-lesson-progress.schema';
 import { LessonItem, ModuleItem, TaskType } from '../common/types/content';
+import { getLocalizedText } from '../common/utils/i18n.util';
 
-const choose = (mt: any, lang: string) => {
-  // Простой выбор языка из MultilingualText; fallback на 'ru'/'en'
-  if (!mt) return '';
-  return mt[lang] || mt['en'] || mt['ru'] || Object.values(mt)[0] || '';
-};
+const choose = (mt: unknown, lang: string) => getLocalizedText(
+  mt as any,
+  lang as any,
+);
 
 export function presentModule(
   doc: CourseModule,


### PR DESCRIPTION
### Motivation
- Ensure lesson `title` and `description` are stored and validated as multilingual objects instead of plain strings for consistent i18n handling.
- Make presence checks for required locales explicit to avoid accepting incomplete multilingual objects.
- Reuse the shared localization helper when presenting lessons to centralize fallback logic.

### Description
- Replaced `title: string` and `description?: string` in `src/modules/content/dto/lesson.dto.ts` with `MultilingualTextDto` and `OptionalMultilingualTextDto` and added nested object validation via `@ValidateNested()` and `@Type()`.
- Tightened `validateMultilingualText` in `src/modules/common/utils/i18n.util.ts` to explicitly check `hasOwnProperty` and ensure each locale value is a non-empty string.
- Switched the `choose()` implementation in `src/modules/content/presenter.ts` to call the shared `getLocalizedText` helper.
- Updated `src/modules/content/__tests__/lesson.dto.spec.ts` to use the multilingual title format and added a test that fails when a locale is missing.

### Testing
- Ran the lesson DTO unit tests with `npx jest src/modules/content/__tests__/lesson.dto.spec.ts` and they passed.
- Test suite result: `1` test suite, `4` tests passed, `0` failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69515eb4ebbc83209e6d3338ec813989)