### PR TITLE
Validate lesson DTO enum values

### DIFF
--- a/src/modules/content/__tests__/lesson.dto.spec.ts
+++ b/src/modules/content/__tests__/lesson.dto.spec.ts
@@ -52,4 +52,18 @@ describe('CreateLessonDto', () => {
 
     expect(errors.some(e => e.property === 'estimatedMinutes')).toBe(true);
   });
+
+  it('should fail when type is invalid', async () => {
+    const dto = plainToInstance(CreateLessonDto, { ...validLesson, type: 'speaking' });
+    const errors = await validate(dto);
+
+    expect(errors.some(e => e.property === 'type')).toBe(true);
+  });
+
+  it('should fail when difficulty is invalid', async () => {
+    const dto = plainToInstance(CreateLessonDto, { ...validLesson, difficulty: 'expert' });
+    const errors = await validate(dto);
+
+    expect(errors.some(e => e.property === 'difficulty')).toBe(true);
+  });
 });

--- a/src/modules/content/dto/lesson.dto.ts
+++ b/src/modules/content/dto/lesson.dto.ts
@@ -31,10 +31,12 @@ export class CreateLessonDto {
   @IsOptional() @IsBoolean()
   published?: boolean;
 
-  @IsOptional() @IsString()
+  @IsOptional()
+  @IsEnum(['conversation', 'vocabulary', 'grammar'])
   type?: 'conversation'|'vocabulary'|'grammar';
 
-  @IsOptional() @IsString()
+  @IsOptional()
+  @IsEnum(['easy', 'medium', 'hard'])
   difficulty?: 'easy'|'medium'|'hard';
 
   @IsOptional() @IsArray()
@@ -60,4 +62,3 @@ export class CreateLessonDto {
 }
 
 export class UpdateLessonDto extends PartialType(CreateLessonDto) {}
-


### PR DESCRIPTION
### Motivation

- Ensure `CreateLessonDto` only accepts known lesson `type` and `difficulty` values to prevent invalid data entering the system.
- Align DTO validation with the shared value sets used in `src/modules/common/types/content.ts` and `src/modules/common/schemas/lesson.schema.ts`.

### Description

- Replace `@IsString()` with `@IsEnum(['conversation','vocabulary','grammar'])` for `type` in `src/modules/content/dto/lesson.dto.ts`.
- Replace `@IsString()` with `@IsEnum(['easy','medium','hard'])` for `difficulty` in `src/modules/content/dto/lesson.dto.ts`.
- Add DTO tests to `src/modules/content/__tests__/lesson.dto.spec.ts` that assert validation fails for invalid `type` (`'speaking'`) and invalid `difficulty` (`'expert'`).

### Testing

- Run `npx jest src/modules/content/__tests__/lesson.dto.spec.ts` to exercise the DTO tests.
- All tests in the file passed (`6 passed, 6 total`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69515fcb78108320af5328cb6425611a)