### PR TITLE
Validate lesson refs against module refs

### DIFF
--- a/src/modules/content/__tests__/lesson.dto.spec.ts
+++ b/src/modules/content/__tests__/lesson.dto.spec.ts
@@ -53,6 +53,13 @@ describe('CreateLessonDto', () => {
     expect(errors.some(e => e.property === 'estimatedMinutes')).toBe(true);
   });
 
+  it('should fail when lessonRef does not match moduleRef', async () => {
+    const dto = plainToInstance(CreateLessonDto, { ...validLesson, lessonRef: 'a0.travel.001' });
+    const errors = await validate(dto);
+
+    expect(errors.some(e => e.property === 'lessonRef')).toBe(true);
+  });
+
   it('should fail when type is invalid', async () => {
     const dto = plainToInstance(CreateLessonDto, { ...validLesson, type: 'speaking' });
     const errors = await validate(dto);

--- a/src/modules/content/__tests__/task-lint.spec.ts
+++ b/src/modules/content/__tests__/task-lint.spec.ts
@@ -31,4 +31,10 @@ describe('lintLessonTasks', () => {
       ])
     );
   });
+
+  it('should report mismatched moduleRef and lessonRef', () => {
+    const errors = lintLessonTasks('a0.basics.001', undefined, 'a0.travel');
+
+    expect(errors).toEqual(expect.arrayContaining(['lessonRef must match a0.travel.NNN']));
+  });
 });

--- a/src/modules/content/admin-content.controller.ts
+++ b/src/modules/content/admin-content.controller.ts
@@ -39,7 +39,7 @@ export class AdminContentController {
   @Post('lessons')
   async createLesson(@Body() body: CreateLessonDto, @Request() req: any) {
     const userId = req.user?.userId; // Get userId from JWT token
-    const errors = lintLessonTasks(body.lessonRef, body.tasks);
+    const errors = lintLessonTasks(body.lessonRef, body.tasks, body.moduleRef);
     if (errors.length) {
       throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }
@@ -56,7 +56,7 @@ export class AdminContentController {
   @Patch('lessons/:lessonRef')
   async updateLesson(@Param('lessonRef') lessonRef: string, @Body() body: UpdateLessonDto, @Request() req: any) {
     const userId = req.user?.userId; // Get userId from JWT token
-    const errors = lintLessonTasks(lessonRef, body.tasks);
+    const errors = lintLessonTasks(lessonRef, body.tasks, body.moduleRef);
     if (errors.length) {
       throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }

--- a/src/modules/content/dto/lesson.dto.ts
+++ b/src/modules/content/dto/lesson.dto.ts
@@ -1,14 +1,47 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsBoolean, IsEnum, IsInt, IsObject, IsOptional, IsString, Min, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+  Validate,
+  ValidateNested,
+  ValidationArguments,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
 import { PartialType } from '@nestjs/mapped-types';
 import { TaskDto } from './task-data.dto';
 import { MultilingualTextDto, OptionalMultilingualTextDto } from './module.dto';
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+@ValidatorConstraint({ name: 'LessonRefMatchesModuleRef', async: false })
+class LessonRefMatchesModuleRefConstraint implements ValidatorConstraintInterface {
+  validate(value: string, args: ValidationArguments): boolean {
+    const dto = args.object as CreateLessonDto;
+    if (typeof value !== 'string' || typeof dto?.moduleRef !== 'string') return false;
+    const pattern = new RegExp(`^${escapeRegExp(dto.moduleRef)}\\.\\d{3}$`);
+    return pattern.test(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const dto = args.object as CreateLessonDto;
+    const moduleRef = typeof dto?.moduleRef === 'string' ? dto.moduleRef : '<moduleRef>';
+    return `lessonRef must match ${moduleRef}.NNN`;
+  }
+}
 
 export class CreateLessonDto {
   @IsString()
   moduleRef!: string;
 
   @IsString()
+  @Validate(LessonRefMatchesModuleRefConstraint)
   lessonRef!: string;
 
   @IsObject()

--- a/src/modules/content/utils/task-lint.ts
+++ b/src/modules/content/utils/task-lint.ts
@@ -1,7 +1,15 @@
 import { TaskDto } from '../dto/task-data.dto';
 
-export function lintLessonTasks(lessonRef: string, tasks?: TaskDto[]): string[] {
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export function lintLessonTasks(lessonRef: string, tasks?: TaskDto[], moduleRef?: string): string[] {
   const errors: string[] = [];
+  if (moduleRef) {
+    const pattern = new RegExp(`^${escapeRegExp(moduleRef)}\\.\\d{3}$`);
+    if (!pattern.test(lessonRef)) {
+      errors.push(`lessonRef must match ${moduleRef}.NNN`);
+    }
+  }
   if (!tasks || tasks.length === 0) return errors;
   const seen = new Set<string>();
   tasks.forEach((t, i) => {
@@ -21,5 +29,4 @@ export function lintLessonTasks(lessonRef: string, tasks?: TaskDto[]): string[] 
   });
   return errors;
 }
-
 


### PR DESCRIPTION
### Motivation
- Ensure `lessonRef` is consistent with its `moduleRef` to prevent data inconsistencies (pattern `^${moduleRef}\.\d{3}$`).
- Catch mismatches early during DTO validation and during admin lesson creation/update linting.
- Strengthen task linting to also verify lesson/module alignment when `moduleRef` is provided.

### Description
- Added a custom class-validator constraint `LessonRefMatchesModuleRefConstraint` and applied it to `CreateLessonDto.lessonRef` to validate `lessonRef` dynamically against `moduleRef`.
- Extended `lintLessonTasks` to accept an optional `moduleRef` and verify `lessonRef` matches the module pattern, and added an `escapeRegExp` helper to build the regex safely.
- Updated `AdminContentController` to pass `body.moduleRef` into `lintLessonTasks` for both lesson creation and update.
- Added tests: a DTO test for mismatched `lessonRef` (`src/modules/content/__tests__/lesson.dto.spec.ts`) and a lint test for module/lesson mismatch (`src/modules/content/__tests__/task-lint.spec.ts`).

### Testing
- Ran `npx jest src/modules/content/__tests__/lesson.dto.spec.ts src/modules/content/__tests__/task-lint.spec.ts`.
- Test results: 2 test suites passed, 10 tests passed (all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695160b795e48320879050f2d5667a47)