### PR TITLE
Introduce task `validationData` and map TaskDto.data for server-side answer validation

### DIFF
--- a/src/modules/common/schemas/lesson.schema.ts
+++ b/src/modules/common/schemas/lesson.schema.ts
@@ -22,7 +22,7 @@ export class Lesson {
   estimatedMinutes?: number;
 
   @Prop({ type: [Object], default: [] })
-  tasks?: Array<{ ref: string; type: string; data: Record<string, any> }>;
+  tasks?: Array<{ ref: string; type: string; data: Record<string, any>; validationData?: Record<string, any> }>;
 
   @Prop({ default: true })
   published?: boolean;
@@ -55,5 +55,4 @@ export class Lesson {
 export const LessonSchema = SchemaFactory.createForClass(Lesson);
 LessonSchema.index({ moduleRef: 1, order: 1 });
 LessonSchema.index({ lessonRef: 1 }, { unique: true });
-
 

--- a/src/modules/common/types/validation-data.ts
+++ b/src/modules/common/types/validation-data.ts
@@ -19,3 +19,10 @@ export interface TranslateValidationData {
 export interface AudioValidationData {
   target?: string;
 }
+
+export type TaskValidationData =
+  | ChoiceValidationData
+  | GapValidationData
+  | OrderValidationData
+  | TranslateValidationData
+  | AudioValidationData;

--- a/src/modules/common/utils/task-validation-data.ts
+++ b/src/modules/common/utils/task-validation-data.ts
@@ -1,0 +1,47 @@
+import { TaskType } from '../types/content';
+import { AudioValidationData, ChoiceValidationData, GapValidationData, OrderValidationData, TaskValidationData, TranslateValidationData } from '../types/validation-data';
+
+const toStringArray = (value: unknown): string[] | undefined =>
+  Array.isArray(value) && value.every(item => typeof item === 'string') ? value : undefined;
+
+export const mapTaskDataToValidationData = (task: { type: TaskType; data?: Record<string, any> }): TaskValidationData | undefined => {
+  const data = task.data;
+  if (!data) return undefined;
+
+  switch (task.type) {
+    case 'choice':
+    case 'multiple_choice': {
+      if (!Array.isArray(data.options) || typeof data.correctIndex !== 'number') return undefined;
+      return {
+        options: data.options,
+        correctIndex: data.correctIndex,
+      } satisfies ChoiceValidationData;
+    }
+    case 'gap': {
+      if (typeof data.answer !== 'string') return undefined;
+      const alternatives = toStringArray(data.accept) ?? toStringArray(data.alternatives);
+      return {
+        answer: data.answer,
+        alternatives,
+      } satisfies GapValidationData;
+    }
+    case 'order': {
+      const tokens = toStringArray(data.tokens);
+      if (!tokens) return undefined;
+      return { tokens } satisfies OrderValidationData;
+    }
+    case 'translate': {
+      const expected = toStringArray(data.expected);
+      if (!expected) return undefined;
+      return { expected } satisfies TranslateValidationData;
+    }
+    case 'listen':
+    case 'speak': {
+      return {
+        target: typeof data.target === 'string' ? data.target : undefined,
+      } satisfies AudioValidationData;
+    }
+    default:
+      return undefined;
+  }
+};

--- a/src/modules/content/dto/task-data.dto.ts
+++ b/src/modules/content/dto/task-data.dto.ts
@@ -221,4 +221,8 @@ export class TaskDto {
     | FlashcardTaskDataDto
     | MatchingTaskDataDto
     | Record<string, any>;
+
+  @IsOptional()
+  @IsObject()
+  validationData?: Record<string, any>;
 }

--- a/src/modules/progress/__tests__/answer-validator.service.spec.ts
+++ b/src/modules/progress/__tests__/answer-validator.service.spec.ts
@@ -34,8 +34,8 @@ describe('AnswerValidatorService', () => {
       lean: jest.fn().mockResolvedValue({
         lessonRef: 'a0.basics.001',
         tasks: [
-          { ref: 't1', type: 'choice', data: { options: ['a', 'b'], correctIndex: 1 } },
-          { ref: 't2', type: 'multiple_choice', data: { options: ['x', 'y'], correctIndex: 0 } },
+          { ref: 't1', type: 'choice', data: { options: ['a', 'b'] }, validationData: { options: ['a', 'b'], correctIndex: 1 } },
+          { ref: 't2', type: 'multiple_choice', data: { options: ['x', 'y'] }, validationData: { options: ['x', 'y'], correctIndex: 0 } },
         ],
       }),
     });
@@ -53,7 +53,7 @@ describe('AnswerValidatorService', () => {
       lean: jest.fn().mockResolvedValue({
         lessonRef: 'a0.basics.001',
         tasks: [
-          { ref: 't1', type: 'gap', data: { answer: 'Hello', alternatives: ['Hi'] } },
+          { ref: 't1', type: 'gap', data: { text: 'Hello ____' }, validationData: { answer: 'Hello', alternatives: ['Hi'] } },
         ],
       }),
     });
@@ -69,7 +69,7 @@ describe('AnswerValidatorService', () => {
       lean: jest.fn().mockResolvedValue({
         lessonRef: 'a0.basics.001',
         tasks: [
-          { ref: 't1', type: 'order', data: { tokens: ['What', 'time', 'is', 'it'] } },
+          { ref: 't1', type: 'order', data: { tokens: ['What', 'time', 'is', 'it'] }, validationData: { tokens: ['What', 'time', 'is', 'it'] } },
         ],
       }),
     });
@@ -85,7 +85,7 @@ describe('AnswerValidatorService', () => {
       lean: jest.fn().mockResolvedValue({
         lessonRef: 'a0.basics.001',
         tasks: [
-          { ref: 't1', type: 'translate', data: { expected: ['Hello there'] } },
+          { ref: 't1', type: 'translate', data: { question: 'Translate' }, validationData: { expected: ['Hello there'] } },
         ],
       }),
     });
@@ -101,8 +101,8 @@ describe('AnswerValidatorService', () => {
       lean: jest.fn().mockResolvedValue({
         lessonRef: 'a0.basics.001',
         tasks: [
-          { ref: 't1', type: 'listen', data: { target: 'hello' } },
-          { ref: 't2', type: 'speak', data: { target: 'hello' } },
+          { ref: 't1', type: 'listen', data: { audioKey: 'audio' }, validationData: { target: 'hello' } },
+          { ref: 't2', type: 'speak', data: { prompt: 'Say hello' }, validationData: { target: 'hello' } },
         ],
       }),
     });

--- a/src/modules/progress/answer-validator.service.ts
+++ b/src/modules/progress/answer-validator.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Lesson, LessonDocument } from '../common/schemas/lesson.schema';
-import { AudioValidationData, ChoiceValidationData, GapValidationData, OrderValidationData, TranslateValidationData } from './validation-data.types';
+import { AudioValidationData, ChoiceValidationData, GapValidationData, OrderValidationData, TranslateValidationData } from '../common/types/validation-data';
+import { mapTaskDataToValidationData } from '../common/utils/task-validation-data';
 
 export interface ValidationResult {
   isCorrect: boolean;
@@ -31,23 +32,30 @@ export class AnswerValidatorService {
     }
 
     // 🔒 ВАЛИДАЦИЯ НА СЕРВЕРЕ ПО ТИПУ ЗАДАЧИ
+    const validationData = (task as { validationData?: Record<string, any> }).validationData
+      ?? mapTaskDataToValidationData({ type: task.type as any, data: task.data });
+
+    if (!validationData) {
+      return { isCorrect: false, score: 0, feedback: 'Missing validation data' };
+    }
+
     switch (task.type) {
       case 'choice':
       case 'multiple_choice':
-        return this.validateChoiceAnswer(task.data as ChoiceValidationData, userAnswer);
+        return this.validateChoiceAnswer(validationData as ChoiceValidationData, userAnswer);
       
       case 'gap':
-        return this.validateGapAnswer(task.data as GapValidationData, userAnswer);
+        return this.validateGapAnswer(validationData as GapValidationData, userAnswer);
       
       case 'order':
-        return this.validateOrderAnswer(task.data as OrderValidationData, userAnswer);
+        return this.validateOrderAnswer(validationData as OrderValidationData, userAnswer);
       
       case 'translate':
-        return this.validateTranslateAnswer(task.data as TranslateValidationData, userAnswer);
+        return this.validateTranslateAnswer(validationData as TranslateValidationData, userAnswer);
       
       case 'listen':
       case 'speak':
-        return this.validateAudioAnswer(task.data as AudioValidationData, userAnswer);
+        return this.validateAudioAnswer(validationData as AudioValidationData, userAnswer);
       
       default:
         return { isCorrect: false, score: 0, feedback: 'Unknown task type' };


### PR DESCRIPTION
### Motivation

- Ensure the answer validator receives a minimal, safe shape of task data instead of relying on raw `TaskDto.data` that may contain secrets.
- Centralize the mapping rules for task types (`choice`, `gap`, `order`, `translate`, `listen`/`speak`) so server validation is deterministic.
- Persist derived `validationData` with lessons at create/update time to avoid recomputing or leaking full task payloads to clients.
- Update validator tests to assert behavior against `validationData` rather than raw task payloads.

### Description

- Added shared validation types in `src/modules/common/types/validation-data.ts` and a union `TaskValidationData` for supported task kinds.
- Implemented `mapTaskDataToValidationData` in `src/modules/common/utils/task-validation-data.ts` to map `TaskDto.data` into the minimal `validationData` shape.
- Extended lesson schema and `TaskDto` to include optional `validationData`, and updated `ContentService.createLesson`/`updateLesson` to populate `validationData` via a `withValidationData` helper.
- Updated `AnswerValidatorService` to use `validationData` (or fall back to the mapper when missing) and adjusted `src/modules/progress/__tests__/answer-validator.service.spec.ts` to use `validationData` fixtures.

### Testing

- Unit tests for the validator were updated in `src/modules/progress/__tests__/answer-validator.service.spec.ts` to assert validation against `validationData`.
- No automated test suite (e.g. `npm test` / `jest`) was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695176f801188320bd50de19a56e2586)