### PR TITLE
Require `expected` answers for translate tasks and enforce in validator

### DIFF
--- a/src/modules/content/__tests__/task-data.dto.spec.ts
+++ b/src/modules/content/__tests__/task-data.dto.spec.ts
@@ -35,4 +35,27 @@ describe('TaskDto', () => {
     const errors = await validate(dto);
     expect(errors.some(e => e.property === 'type')).toBe(true);
   });
+
+  it('should validate translate task data with expected answers', async () => {
+    const dto = plainToInstance(TaskDto, {
+      ref: 'a0.basics.001.t4',
+      type: 'translate',
+      data: { question: 'Переведи', expected: ['Hello'] },
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should fail translate task data without expected answers', async () => {
+    const dto = plainToInstance(TaskDto, {
+      ref: 'a0.basics.001.t5',
+      type: 'translate',
+      data: { question: 'Переведи' },
+    });
+
+    const errors = await validate(dto);
+    const dataError = errors.find(error => error.property === 'data');
+    expect(dataError).toBeDefined();
+  });
 });

--- a/src/modules/content/dto/task-data.dto.ts
+++ b/src/modules/content/dto/task-data.dto.ts
@@ -1,5 +1,6 @@
 import { Type } from 'class-transformer';
 import {
+  ArrayNotEmpty,
   IsArray,
   IsBoolean,
   IsInt,
@@ -122,6 +123,11 @@ export class TranslateTaskDataDto {
   @IsString()
   @IsNotEmpty()
   question!: string; // e.g., "Переведи: 'сколько это стоит?'"
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  expected!: string[];
 }
 
 export class FlashcardTaskDataDto {

--- a/src/modules/progress/__tests__/answer-validator.service.spec.ts
+++ b/src/modules/progress/__tests__/answer-validator.service.spec.ts
@@ -96,6 +96,21 @@ describe('AnswerValidatorService', () => {
     expect(result.score).toBe(1);
   });
 
+  it('throws when translate expected answers are missing', async () => {
+    mockLessonModel.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        lessonRef: 'a0.basics.001',
+        tasks: [
+          { ref: 't1', type: 'translate', data: { question: 'Translate' } },
+        ],
+      }),
+    });
+
+    await expect(service.validateAnswer('a0.basics.001', 't1', 'Hello')).rejects.toThrow(
+      'Missing expected answers for translate task',
+    );
+  });
+
   it('validates listen/speak answers with audio similarity', async () => {
     mockLessonModel.findOne.mockReturnValue({
       lean: jest.fn().mockResolvedValue({

--- a/src/modules/progress/answer-validator.service.ts
+++ b/src/modules/progress/answer-validator.service.ts
@@ -35,6 +35,13 @@ export class AnswerValidatorService {
     const validationData = (task as { validationData?: Record<string, any> }).validationData
       ?? mapTaskDataToValidationData({ type: task.type as any, data: task.data });
 
+    if (task.type === 'translate') {
+      const expected = (validationData as TranslateValidationData | undefined)?.expected;
+      if (!expected?.length) {
+        throw new Error('Missing expected answers for translate task');
+      }
+    }
+
     if (!validationData) {
       return { isCorrect: false, score: 0, feedback: 'Missing validation data' };
     }
@@ -112,7 +119,11 @@ export class AnswerValidatorService {
   }
 
   private validateTranslateAnswer(taskData: TranslateValidationData, userAnswer: string): ValidationResult {
-    const expected = taskData.expected || [];
+    if (!taskData.expected?.length) {
+      throw new Error('Missing expected answers for translate task');
+    }
+
+    const { expected } = taskData;
     const user = userAnswer.toLowerCase().trim();
     
     // Проверяем все возможные варианты перевода


### PR DESCRIPTION
### Motivation

- Ensure translate tasks carry a canonical list of correct translations so server-side validation has a single source of truth.
- Make the `AnswerValidatorService` rely on `expected` answers and fail fast if they are missing to avoid silent incorrect validation.
- Keep `TranslateValidationData.expected` as the mandatory truth source for translate validation flows.

### Description

- Added a required `expected!: string[]` field to the `TranslateTaskDataDto` with `@IsArray`, `@ArrayNotEmpty`, and `@IsString({ each: true })` in `src/modules/content/dto/task-data.dto.ts`.
- Enforced presence of `expected` early in `AnswerValidatorService.validateAnswer` for `translate` tasks and added an explicit check inside `validateTranslateAnswer` to throw `Missing expected answers for translate task` when absent in `src/modules/progress/answer-validator.service.ts`.
- Left the `TranslateValidationData` type (`expected: string[]`) unchanged as the authoritative type in `src/modules/common/types/validation-data.ts` and continued mapping logic in `mapTaskDataToValidationData`.
- Updated tests in `src/modules/content/__tests__/task-data.dto.spec.ts` and `src/modules/progress/__tests__/answer-validator.service.spec.ts` to cover valid `translate` DTOs, failing DTOs without `expected`, and validator behavior when `expected` is missing.

### Testing

- Updated unit tests: `src/modules/content/__tests__/task-data.dto.spec.ts` and `src/modules/progress/__tests__/answer-validator.service.spec.ts` to include translate cases.
- No automated test suite was executed as part of this change (tests were modified but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951785d2c048320b6421989a4f285f0)