### PR TITLE
Require gap answer and map `accept` → `alternatives` in validation

### DIFF
--- a/src/modules/content/__tests__/task-data.dto.spec.ts
+++ b/src/modules/content/__tests__/task-data.dto.spec.ts
@@ -18,7 +18,7 @@ describe('TaskDto', () => {
     const dto = plainToInstance(TaskDto, {
       ref: 'a0.basics.001.t2',
       type: 'gap',
-      data: { text: 'It costs ____ dollars' },
+      data: { text: 'It costs ____ dollars', answer: '10' },
     });
 
     const errors = await validate(dto);

--- a/src/modules/content/dto/task-data.dto.ts
+++ b/src/modules/content/dto/task-data.dto.ts
@@ -54,9 +54,9 @@ export class GapTaskDataDto {
   @IsNotEmpty()
   text!: string; // e.g., "It costs ____ dollars"
 
-  @IsOptional()
   @IsString()
-  answer?: string; // correct answer for the gap
+  @IsNotEmpty()
+  answer!: string; // correct answer for the gap
 
   @IsArray()
   @IsString({ each: true })

--- a/src/modules/progress/__tests__/answer-validator.service.spec.ts
+++ b/src/modules/progress/__tests__/answer-validator.service.spec.ts
@@ -53,7 +53,7 @@ describe('AnswerValidatorService', () => {
       lean: jest.fn().mockResolvedValue({
         lessonRef: 'a0.basics.001',
         tasks: [
-          { ref: 't1', type: 'gap', data: { text: 'Hello ____' }, validationData: { answer: 'Hello', alternatives: ['Hi'] } },
+          { ref: 't1', type: 'gap', data: { text: 'Hello ____', answer: 'Hello', accept: ['Hi'] } },
         ],
       }),
     });


### PR DESCRIPTION
### Motivation
- Ensure gap tasks always provide a primary expected value (`answer`) for validation.
- Support legacy/alternate synonyms provided under `accept` by mapping them into validation `alternatives`.
- Treat `answer` as the main expected value and `alternatives` as acceptable variants during answer checking.
- Update tests to cover the `accept`→`alternatives` mapping and the required `answer` constraint.

### Description
- Make `answer` required in `GapTaskDataDto` by replacing `@IsOptional()` with `@IsNotEmpty()` and using a non-optional field.
- Update `src/modules/content/__tests__/task-data.dto.spec.ts` to include `answer` in the sample gap task data.
- Update `src/modules/progress/__tests__/answer-validator.service.spec.ts` to provide `accept` inside task `data` so it is mapped to `alternatives` via `mapTaskDataToValidationData`.
- No changes to core validator logic were required, tests now exercise the mapping and required DTO constraint.

### Testing
- Ran `npx jest src/modules/content/__tests__/task-data.dto.spec.ts src/modules/progress/__tests__/answer-validator.service.spec.ts`.
- Both test suites passed successfully.
- Test summary: `Test Suites: 2 passed`, `Tests: 11 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69517936625c83208fe9e8bf3a041ded)