### PR TITLE
Require `correctIndex` for choice/multiple_choice tasks and update lint/tests

### DIFF
--- a/src/modules/content/__tests__/admin-content.controller.spec.ts
+++ b/src/modules/content/__tests__/admin-content.controller.spec.ts
@@ -485,7 +485,7 @@ describe('AdminContentController', () => {
             {
               ref: 'wrong-prefix.t1',
               type: 'choice',
-              data: { question: 'Pick one', options: ['a'] },
+              data: { question: 'Pick one', options: ['a'], correctIndex: 0 },
             },
             {
               ref: 'wrong-prefix.t1',
@@ -502,11 +502,28 @@ describe('AdminContentController', () => {
           'duplicate task.ref: wrong-prefix.t1',
           'task[0].ref must start with a0.basics.001.',
           'choice[0] requires >=2 options',
-          'choice[0] missing correctIndex',
           'gap[1].text must contain ____',
           'gap[1].answer is required',
         ])
       );
+      expect(mockContentService.createLesson).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when choice task is missing correctIndex', async () => {
+      await request(app.getHttpServer())
+        .post('/admin/content/lessons')
+        .send({
+          ...validLesson,
+          tasks: [
+            {
+              ref: 'a0.basics.001.t1',
+              type: 'choice',
+              data: { question: 'Pick one', options: ['a', 'b'] },
+            },
+          ],
+        })
+        .expect(400);
+
       expect(mockContentService.createLesson).not.toHaveBeenCalled();
     });
 

--- a/src/modules/content/__tests__/task-data.dto.spec.ts
+++ b/src/modules/content/__tests__/task-data.dto.spec.ts
@@ -14,6 +14,30 @@ describe('TaskDto', () => {
     expect(errors).toHaveLength(0);
   });
 
+  it('should fail choice task data without correctIndex', async () => {
+    const dto = plainToInstance(TaskDto, {
+      ref: 'a0.basics.001.t1',
+      type: 'choice',
+      data: { question: 'Pick', options: ['a', 'b'] },
+    });
+
+    const errors = await validate(dto);
+    const dataError = errors.find(error => error.property === 'data');
+    expect(dataError).toBeDefined();
+  });
+
+  it('should fail multiple_choice task data without correctIndex', async () => {
+    const dto = plainToInstance(TaskDto, {
+      ref: 'a0.basics.001.t1',
+      type: 'multiple_choice',
+      data: { question: 'Pick', options: ['a', 'b'] },
+    });
+
+    const errors = await validate(dto);
+    const dataError = errors.find(error => error.property === 'data');
+    expect(dataError).toBeDefined();
+  });
+
   it('should validate gap task data', async () => {
     const dto = plainToInstance(TaskDto, {
       ref: 'a0.basics.001.t2',

--- a/src/modules/content/__tests__/task-lint.spec.ts
+++ b/src/modules/content/__tests__/task-lint.spec.ts
@@ -32,6 +32,19 @@ describe('lintLessonTasks', () => {
     );
   });
 
+  it('should validate multiple_choice task fields', () => {
+    const errors = lintLessonTasks('a0.basics.001', [
+      { ref: 'a0.basics.001.t1', type: 'multiple_choice', data: { options: ['a'] } },
+    ] as any);
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        'multiple_choice[0] requires >=2 options',
+        'multiple_choice[0] missing correctIndex',
+      ])
+    );
+  });
+
   it('should report mismatched moduleRef and lessonRef', () => {
     const errors = lintLessonTasks('a0.basics.001', undefined, 'a0.travel');
 

--- a/src/modules/content/dto/task-data.dto.ts
+++ b/src/modules/content/dto/task-data.dto.ts
@@ -40,9 +40,8 @@ export class ChoiceTaskDataDto {
   @IsString({ each: true })
   options!: string[];
 
-  @IsOptional()
   @IsNumber()
-  correctIndex?: number; // Index of correct answer
+  correctIndex!: number; // Index of correct answer
 
   @IsOptional()
   @IsString()

--- a/src/modules/content/utils/task-lint.ts
+++ b/src/modules/content/utils/task-lint.ts
@@ -16,10 +16,11 @@ export function lintLessonTasks(lessonRef: string, tasks?: TaskDto[], moduleRef?
     if (seen.has(t.ref)) errors.push(`duplicate task.ref: ${t.ref}`);
     seen.add(t.ref);
     if (!t.ref.startsWith(`${lessonRef}.`)) errors.push(`task[${i}].ref must start with ${lessonRef}.`);
-    if (t.type === 'choice') {
+    if (t.type === 'choice' || t.type === 'multiple_choice') {
+      const label = t.type;
       const d = t.data as any;
-      if (!Array.isArray(d.options) || d.options.length < 2) errors.push(`choice[${i}] requires >=2 options`);
-      if (typeof d.correctIndex !== 'number') errors.push(`choice[${i}] missing correctIndex`);
+      if (!Array.isArray(d.options) || d.options.length < 2) errors.push(`${label}[${i}] requires >=2 options`);
+      if (typeof d.correctIndex !== 'number') errors.push(`${label}[${i}] missing correctIndex`);
     }
     if (t.type === 'gap') {
       const d = t.data as any;
@@ -29,4 +30,3 @@ export function lintLessonTasks(lessonRef: string, tasks?: TaskDto[], moduleRef?
   });
   return errors;
 }
-


### PR DESCRIPTION
### Motivation
- Ensure task DTOs enforce an explicit correct answer index for choice-style tasks to prevent ambiguous data.
- Make server-side linting and DTO validation consistent for both `choice` and `multiple_choice` task types.
- Prevent lessons with malformed tasks from being created or updated via admin endpoints.
- Keep tests aligned with the stricter validation rules.

### Description
- Made `ChoiceTaskDataDto.correctIndex` required by removing `@IsOptional()` and changing the property to `correctIndex!: number` in `src/modules/content/dto/task-data.dto.ts`.
- Extended `lintLessonTasks` in `src/modules/content/utils/task-lint.ts` to validate both `choice` and `multiple_choice` types and to report errors using the task type label.
- Added unit tests to assert missing `correctIndex` fails for `choice` and `multiple_choice` in `src/modules/content/__tests__/task-data.dto.spec.ts` and added lint tests for `multiple_choice` in `src/modules/content/__tests__/task-lint.spec.ts`.
- Updated admin controller tests in `src/modules/content/__tests__/admin-content.controller.spec.ts` to reflect the new validation behavior and adjusted an existing invalid-case test accordingly.

### Testing
- No automated test suite was executed as part of this change.
- Unit test files modified: `src/modules/content/__tests__/task-data.dto.spec.ts`, `src/modules/content/__tests__/task-lint.spec.ts`, and `src/modules/content/__tests__/admin-content.controller.spec.ts`.
- Changes were committed locally and include updates to test expectations to cover the stricter validations.
- Manual linting and static checks were not reported here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69517d6dc67c83208fe95dda6fd3b9f2)