### PR TITLE
Make gap task answer optional in DTO validation

### DIFF
--- a/src/modules/content/dto/task-data.dto.ts
+++ b/src/modules/content/dto/task-data.dto.ts
@@ -53,6 +53,7 @@ export class GapTaskDataDto {
   @IsNotEmpty()
   text!: string; // e.g., "It costs ____ dollars"
 
+  @IsOptional()
   @IsString()
   @IsNotEmpty()
   answer!: string; // correct answer for the gap


### PR DESCRIPTION
### Motivation
- Allow requests that omit the gap `answer` field to pass DTO validation so they reach the lesson linter which emits the specific lint error.
- Ensure the linter (`lintLessonTasks`) remains responsible for reporting "gap[i].answer is required" rather than class-validator rejecting the request.
- Preserve existing validation behavior for other task types so they continue to be validated by their DTOs.

### Description
- Add `@IsOptional()` to `GapTaskDataDto.answer` so missing `answer` does not cause DTO validation failure.
- Keep `@IsString()` and `@IsNotEmpty()` on `answer` so provided answers are still validated.
- No other task-type DTOs or validators were modified.

### Testing
- No automated tests were run as part of this change.
- Existing automated tests were not executed, so behavior should be validated by CI or local test runs to confirm admin-content linting now surfaces the gap lint error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695183ca0fd48320aeba46ed3c622e7f)