### PR TITLE
Redact lesson tasks in content v2 responses

### DIFF
--- a/src/modules/common/utils/mappers.ts
+++ b/src/modules/common/utils/mappers.ts
@@ -8,7 +8,7 @@ import { ModuleItem, LessonItem, LessonProgress, VocabularyItem as VocabType, Ta
 import { getLocalizedText, SupportedLanguage } from './i18n.util';
 
 const STRIP = new Set(['correct','isCorrect','correctIndex','correctIndexes','answer','answers','expected','expectedAnswers','target','targets','solution','solutions']);
-const redact = (v: any): any =>
+export const redact = (v: any): any =>
   Array.isArray(v) ? v.map(redact)
   : v && typeof v === 'object'
     ? Object.fromEntries(Object.entries(v).filter(([k]) => !STRIP.has(k)).map(([k, val]) => [k, redact(val)]))

--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -6,6 +6,8 @@ import { CourseModule, CourseModuleDocument } from '../common/schemas/course-mod
 import { Lesson, LessonDocument } from '../common/schemas/lesson.schema';
 import { UserLessonProgress, UserLessonProgressDocument } from '../common/schemas/user-lesson-progress.schema';
 import { User, UserDocument } from '../common/schemas/user.schema';
+import { TaskType } from '../common/types/content';
+import { redact } from '../common/utils/mappers';
 import { presentLesson, presentModule } from './presenter';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { GetModulesDto } from './dto/get-content.dto';
@@ -137,7 +139,11 @@ export class ContentV2Controller {
     const p = await this.progressModel.findOne({ userId: String(userId), lessonRef }).lean();
     // detailed: вернём ещё tasks
     const presented = presentLesson(l as any, lang, p as any);
-    (presented as any).tasks = l.tasks || [];
+    (presented as any).tasks = (l.tasks || []).map(({ ref, type, data }) => ({
+      ref,
+      type: type as TaskType,
+      data: redact(data),
+    }));
     return presented;
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent leaking task answer fields (like `correctIndex`, `answer`, `expected`, etc.) from the v2 lesson endpoint.
- Reuse the existing redaction logic used by mappers to keep behavior consistent between v1 and v2.
- Ensure returned tasks keep their `TaskType` and other public fields while sensitive fields are stripped.

### Description
- Exported the shared `redact` helper from `src/modules/common/utils/mappers.ts`.
- Imported `redact` and `TaskType` into `src/modules/content/content-v2.controller.ts` and replaced the direct `(presented as any).tasks = l.tasks || []` assignment.
- Now the v2 lesson response maps tasks to `{ ref, type: type as TaskType, data: redact(data) }` to preserve types and redact answers.
- No other endpoint behavior was changed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518e23cf608320961f767621cb265b)