### PR TITLE
Use `request.user?.userId` in LessonPrerequisiteGuard with legacy fallback

### DIFF
--- a/src/modules/content/guards/lesson-prerequisite.guard.ts
+++ b/src/modules/content/guards/lesson-prerequisite.guard.ts
@@ -14,7 +14,11 @@ export class LessonPrerequisiteGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
     const lessonRef = request.params?.lessonRef;
-    const userId = request.query?.userId || request.body?.userId || request.params?.userId;
+    const userId =
+      request.user?.userId ||
+      request.query?.userId ||
+      request.body?.userId ||
+      request.params?.userId;
 
     if (!lessonRef) {
       throw new BadRequestException('lessonRef is required');


### PR DESCRIPTION
### Motivation
- Ensure the lesson prerequisite guard uses the authenticated user id from the JWT payload instead of relying on query/body/params.
- Keep compatibility with legacy clients that may still send `userId` via query, body or params.
- Prevent `ContentController.getLesson` (which reads `req.user?.userId`) from failing when the guard expects an explicit `userId` in query/body/params.

### Description
- Update `LessonPrerequisiteGuard` to obtain `userId` from `request.user?.userId` first and then fall back to `request.query?.userId`, `request.body?.userId`, and `request.params?.userId`.
- Preserve existing validation that throws `BadRequestException('userId is required')` when no user identifier is available.
- No other behavior around lesson lookup or prerequisite checks was changed.

### Testing
- No automated tests were executed as part of this change.
- Manual inspection confirms `getLesson` already reads `req.user?.userId` and the guard now aligns with that behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518eaa0dd48320bf4f9f5a20fc929e)