### PR TITLE
Add validation for `matching`/`match` and `flashcard` tasks and support `listening` alias

### DIFF
--- a/src/modules/common/types/validation-data.ts
+++ b/src/modules/common/types/validation-data.ts
@@ -20,9 +20,20 @@ export interface AudioValidationData {
   target?: string;
 }
 
+export interface MatchingValidationData {
+  pairs: Array<{ left: string; right: string }>;
+}
+
+export interface FlashcardValidationData {
+  back?: string;
+  expected?: string[];
+}
+
 export type TaskValidationData =
   | ChoiceValidationData
   | GapValidationData
   | OrderValidationData
   | TranslateValidationData
-  | AudioValidationData;
+  | AudioValidationData
+  | MatchingValidationData
+  | FlashcardValidationData;

--- a/src/modules/common/utils/task-validation-data.ts
+++ b/src/modules/common/utils/task-validation-data.ts
@@ -1,5 +1,5 @@
 import { TaskType } from '../types/content';
-import { AudioValidationData, ChoiceValidationData, GapValidationData, OrderValidationData, TaskValidationData, TranslateValidationData } from '../types/validation-data';
+import { AudioValidationData, ChoiceValidationData, FlashcardValidationData, GapValidationData, MatchingValidationData, OrderValidationData, TaskValidationData, TranslateValidationData } from '../types/validation-data';
 
 const toStringArray = (value: unknown): string[] | undefined =>
   Array.isArray(value) && value.every(item => typeof item === 'string') ? value : undefined;
@@ -36,10 +36,28 @@ export const mapTaskDataToValidationData = (task: { type: TaskType; data?: Recor
       return { expected } satisfies TranslateValidationData;
     }
     case 'listen':
+    case 'listening':
     case 'speak': {
       return {
         target: typeof data.target === 'string' ? data.target : undefined,
       } satisfies AudioValidationData;
+    }
+    case 'match':
+    case 'matching': {
+      if (!Array.isArray(data.pairs)) return undefined;
+      const pairs = data.pairs
+        .filter((pair: { left?: unknown; right?: unknown }) => typeof pair?.left === 'string' && typeof pair?.right === 'string')
+        .map((pair: { left: string; right: string }) => ({ left: pair.left, right: pair.right }));
+      return {
+        pairs,
+      } satisfies MatchingValidationData;
+    }
+    case 'flashcard': {
+      const expected = toStringArray(data.expected);
+      return {
+        back: typeof data.back === 'string' ? data.back : undefined,
+        expected,
+      } satisfies FlashcardValidationData;
     }
     default:
       return undefined;


### PR DESCRIPTION
### Motivation
- Support additional task types used in DTOs by providing server-side validation for `listening`, `matching`/`match`, and `flashcard` tasks.
- Provide a minimal but useful validation/score for matching pairs and flashcard review flow to enable consistent progress scoring.
- Keep server mapping aligned with the single source of truth `TASK_TYPES` in `task-data.dto.ts`.
- Avoid silent unknown-task behavior by returning meaningful feedback for these types.

### Description
- Added `MatchingValidationData` and `FlashcardValidationData` to `src/modules/common/types/validation-data.ts` and extended `TaskValidationData` to include them.
- Extended `mapTaskDataToValidationData` in `src/modules/common/utils/task-validation-data.ts` to handle `listening` (alias), `match`/`matching` (maps `pairs`), and `flashcard` (maps `back`/`expected`).
- Implemented `validateMatchingAnswer` and `validateFlashcardAnswer` in `src/modules/progress/answer-validator.service.ts`, and wired them into `validateAnswer` alongside existing validators, while also accepting several answer formats (indexes, arrays, objects) for matching.
- Minor imports and type adjustments to ensure the new validation data types are used by `mapTaskDataToValidationData` and the answer validator.

### Testing
- No automated tests were run as part of this change.
- Type-checking and runtime tests were not executed in this rollout.
- Manual static inspection was used to ensure new code follows existing patterns for validators.
- Further automated tests should be added to validate matching and flashcard scoring logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518ed83f488320b50aa5be5043c66c)