### PR TITLE
Make SubmitAnswerDto.userId optional

### DIFF
--- a/src/modules/progress/__tests__/submit-answer.dto.spec.ts
+++ b/src/modules/progress/__tests__/submit-answer.dto.spec.ts
@@ -5,7 +5,6 @@ import { SubmitAnswerDto } from '../dto/submit-answer.dto';
 describe('SubmitAnswerDto', () => {
   it('should validate a valid payload', async () => {
     const dto = plainToInstance(SubmitAnswerDto, {
-      userId: 'user-1',
       lessonRef: 'a0.basics.001',
       taskRef: 'a0.basics.001.t1',
       userAnswer: '1',
@@ -21,7 +20,6 @@ describe('SubmitAnswerDto', () => {
     const dto = plainToInstance(SubmitAnswerDto, { lessonRef: 'a0.basics.001' });
     const errors = await validate(dto);
 
-    expect(errors.some(e => e.property === 'userId')).toBe(true);
     expect(errors.some(e => e.property === 'taskRef')).toBe(true);
     expect(errors.some(e => e.property === 'userAnswer')).toBe(true);
   });

--- a/src/modules/progress/dto/submit-answer.dto.ts
+++ b/src/modules/progress/dto/submit-answer.dto.ts
@@ -1,8 +1,9 @@
 import { IsString, IsOptional, IsNumber, IsBoolean, Min } from 'class-validator';
 
 export class SubmitAnswerDto {
+  @IsOptional()
   @IsString()
-  userId!: string;
+  userId?: string;
 
   @IsString()
   lessonRef!: string;


### PR DESCRIPTION
### Motivation
- Allow the server to rely on authenticated user information instead of requiring clients to send `userId` in the payload.
- Prevent client-supplied `userId` from being mandatory and reduce redundancy with the JWT-provided `req.user.userId`.
- Keep DTO validation aligned with the controller behavior which reads user identity from the request.

### Description
- Marked `SubmitAnswerDto.userId` as optional by adding `@IsOptional()` and changing the type to `userId?: string`.
- Updated `src/modules/progress/__tests__/submit-answer.dto.spec.ts` to remove the required `userId` field from the valid payload and to stop asserting that `userId` is required.
- No changes were required in the controller because it already uses `req.user.userId` for the request user.

### Testing
- Updated unit test file `src/modules/progress/__tests__/submit-answer.dto.spec.ts` to reflect the optional `userId` behavior.
- The automated test suite was not executed as part of this change (no `jest` run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518f70fab083208e955936b18b31f8)