### PR TITLE
Align default estimatedMinutes to schema value (10)

### DIFF
--- a/src/modules/common/utils/mappers.ts
+++ b/src/modules/common/utils/mappers.ts
@@ -53,7 +53,7 @@ export class LessonMapper {
       moduleRef: lesson.moduleRef,
       title: getLocalizedText(lesson.title, language),
       description: getLocalizedText(lesson.description, language),
-      estimatedMinutes: lesson.estimatedMinutes || 8,
+      estimatedMinutes: lesson.estimatedMinutes || 10,
       order: lesson.order || 0,
       type: lesson.type,
       difficulty: lesson.difficulty,

--- a/src/modules/content/presenter.ts
+++ b/src/modules/content/presenter.ts
@@ -44,7 +44,7 @@ export function presentLesson(
     moduleRef: doc.moduleRef,
     title: choose(doc.title, lang),
     description: choose(doc.description, lang),
-    estimatedMinutes: doc.estimatedMinutes ?? 8,
+    estimatedMinutes: doc.estimatedMinutes ?? 10,
     order: doc.order ?? 0,
     type: doc.type || 'vocabulary',
     difficulty: doc.difficulty || 'easy',


### PR DESCRIPTION
### Motivation
- The schema `Lesson` in `src/modules/common/schemas/lesson.schema.ts` defines `estimatedMinutes` default as `10`, but other places used `8` causing inconsistency.
- Ensure DTOs and presented lesson objects consistently reflect the schema default of `10` minutes.
- Prevent unexpected behavior when `estimatedMinutes` is missing by unifying fallback values across the codebase.

### Description
- Updated `src/modules/common/utils/mappers.ts` to use `estimatedMinutes: lesson.estimatedMinutes || 10` instead of `8`.
- Updated `src/modules/content/presenter.ts` to use `estimatedMinutes: doc.estimatedMinutes ?? 10` instead of `8`.
- Kept `src/modules/common/schemas/lesson.schema.ts` unchanged since its `@Prop({ default: 10 }) estimatedMinutes` already defines the desired default.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69518fe9cccc8320b296176837081dce)