### PR TITLE
Validate moduleRef and lessonRef formats in content v2

### DIFF
--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -1,5 +1,5 @@
 // src/content/content-v2.controller.ts
-import { Controller, Get, Param, Query, UseGuards, Request, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Param, Query, UseGuards, Request, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CourseModule, CourseModuleDocument } from '../common/schemas/course-module.schema';
@@ -118,6 +118,10 @@ export class ContentV2Controller {
       return { error: 'userId is required' };
     }
 
+    if (!/^[a-z0-9]+\.[a-z0-9_]+$/.test(moduleRef)) {
+      throw new BadRequestException('Invalid moduleRef format');
+    }
+
     const lessons = await this.lessonModel.find({ moduleRef, published: true }).sort({ order: 1 }).lean();
     const progresses = await this.progressModel.find({ userId: String(userId), moduleRef }).lean();
 
@@ -130,6 +134,10 @@ export class ContentV2Controller {
     const userId = req.user?.userId; // Get userId from JWT token
     if (!userId) {
       return { error: 'userId is required' };
+    }
+
+    if (!/^[a-z0-9]+\.[a-z0-9_]+\.\d{3}$/.test(lessonRef)) {
+      throw new BadRequestException('Invalid lessonRef format');
     }
 
     const l = await this.lessonModel.findOne({ lessonRef, published: true }).lean();


### PR DESCRIPTION
### Motivation
- Ensure `content/v2` endpoints enforce the same reference format rules as the legacy `content` controller (v1).
- Prevent malformed `moduleRef` and `lessonRef` values from reaching DB queries or causing inconsistent behavior.
- Align error handling with v1 by returning a clear bad-request error when refs are invalid.
- Improve API input validation to reduce potential runtime errors and malformed requests.

### Description
- Added `BadRequestException` import and format checks in `src/modules/content/content-v2.controller.ts` for `moduleRef` and `lessonRef` parameters.
- Validates `moduleRef` with the regex `^[a-z0-9]+\.[a-z0-9_]+$` and throws `BadRequestException('Invalid moduleRef format')` on failure.
- Validates `lessonRef` with the regex `^[a-z0-9]+\.[a-z0-9_]+\.\d{3}$` and throws `BadRequestException('Invalid lessonRef format')` on failure.
- Changes are limited to `getLessons` and `getLesson` handlers to match v1 behavior and avoid altering other logic.

### Testing
- No automated unit or integration tests were executed as part of this change.
- Linting and build checks were not run in this rollout.
- Manual verification was not recorded in automated test output.
- Recommend adding unit tests for `getLessons` and `getLesson` parameter validation in a follow-up change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951904cd8e483209fc9409af932a4c4)