### PR TITLE
Уточнить типы уроков в сервисе контента

### DIFF
--- a/src/modules/content/admin-content.controller.ts
+++ b/src/modules/content/admin-content.controller.ts
@@ -37,13 +37,12 @@ export class AdminContentController {
 
   // Lessons
   @Post('lessons')
-  async createLesson(@Body() body: CreateLessonDto, @Request() req: any) {
-    const userId = req.user?.userId; // Get userId from JWT token
+  async createLesson(@Body() body: CreateLessonDto) {
     const errors = lintLessonTasks(body.lessonRef, body.tasks, body.moduleRef);
     if (errors.length) {
       throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }
-    const doc = await this.content.createLesson(body as any);
+    const doc = await this.content.createLesson(body);
     return { id: (doc as any)._id };
   }
 
@@ -54,12 +53,11 @@ export class AdminContentController {
   }
 
   @Patch('lessons/:lessonRef')
-  async updateLesson(@Param('lessonRef') lessonRef: string, @Body() body: UpdateLessonDto, @Request() req: any) {
-    const userId = req.user?.userId; // Get userId from JWT token
+  async updateLesson(@Param('lessonRef') lessonRef: string, @Body() body: UpdateLessonDto) {
     const errors = lintLessonTasks(lessonRef, body.tasks, body.moduleRef);
     if (errors.length) {
       throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }
-    return this.content.updateLesson(lessonRef, body as any);
+    return this.content.updateLesson(lessonRef, body);
   }
 }

--- a/src/modules/content/content.service.ts
+++ b/src/modules/content/content.service.ts
@@ -7,6 +7,17 @@ import { UserLessonProgress, UserLessonProgressDocument } from '../common/schema
 import { MultilingualText, OptionalMultilingualText } from '../common/utils/i18n.util';
 import { mapTaskDataToValidationData } from '../common/utils/task-validation-data';
 import { TaskValidationData } from '../common/types/validation-data';
+import { CreateLessonDto, UpdateLessonDto } from './dto/lesson.dto';
+
+type CreateLessonInput = Omit<CreateLessonDto, 'title' | 'description'> & {
+  title: MultilingualText;
+  description?: OptionalMultilingualText;
+};
+
+type UpdateLessonInput = Omit<UpdateLessonDto, 'title' | 'description'> & {
+  title?: MultilingualText;
+  description?: OptionalMultilingualText;
+};
 
 @Injectable()
 export class ContentService {
@@ -34,7 +45,7 @@ export class ContentService {
   }
 
   // Lessons
-  async createLesson(body: { moduleRef: string; lessonRef: string; title: string; description?: string; estimatedMinutes?: number; tasks?: Array<{ ref: string; type: string; data: Record<string, any>; validationData?: TaskValidationData }>; order?: number; published?: boolean }) {
+  async createLesson(body: CreateLessonInput) {
     const tasks = this.withValidationData(body.tasks);
     return this.lessonModel.create({ ...body, tasks });
   }
@@ -45,7 +56,7 @@ export class ContentService {
     return this.lessonModel.find(q).sort({ moduleRef: 1, order: 1 }).lean();
   }
 
-  async updateLesson(lessonRef: string, update: Partial<Lesson>) {
+  async updateLesson(lessonRef: string, update: UpdateLessonInput) {
     const nextUpdate = { ...update } as Partial<Lesson>;
     if (update.tasks) {
       nextUpdate.tasks = this.withValidationData(update.tasks as Lesson['tasks']);


### PR DESCRIPTION
### Motivation
- Согласовать сигнатуры сервиса с DTO, чтобы поля `title`/`description` были мультиязычными и соответствовали `CreateLessonDto`/`UpdateLessonDto`.
- Убрать небезопасные приведения к `any` в контроллере и передавать корректные типы в сервис.

### Description
- Обновил `src/modules/content/content.service.ts`: импортировал `CreateLessonDto`/`UpdateLessonDto` и добавил типы `CreateLessonInput` и `UpdateLessonInput`, где `title`/`description` представлены как `MultilingualText`/`OptionalMultilingualText`.
- Изменил сигнатуры методов сервиса на `createLesson(body: CreateLessonInput)` и `updateLesson(lessonRef: string, update: UpdateLessonInput)` и сохранил логику добавления `validationData` для задач.
- Исправил `src/modules/content/admin-content.controller.ts`: убрал приведения `as any` и параметры `req` из методов `createLesson`/`updateLesson`, теперь контроллер напрямую передаёт `CreateLessonDto`/`UpdateLessonDto` в сервис.

### Testing
- Автоматические тесты не запускались.
- Изменения ограничены типизацией и не меняют поведение БД или внешние контракты, поэтому ручная проверка через админ-эндпойнты рекомендуется.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695192f9b7d4832094e3cc5c873e2f43)