### PR TITLE
Унифицировал нормализацию дефолтов урока

### DIFF
--- a/src/modules/common/__tests__/mappers.spec.ts
+++ b/src/modules/common/__tests__/mappers.spec.ts
@@ -27,6 +27,8 @@ describe('LessonMapper', () => {
 
     expect(result.estimatedMinutes).toBe(10);
     expect(result.xpReward).toBe(25);
+    expect(result.type).toBe('vocabulary');
+    expect(result.difficulty).toBe('easy');
     expect(result.hasAudio).toBe(true);
     expect(result.hasVideo).toBe(false);
     expect(result.order).toBe(0);

--- a/src/modules/common/utils/lesson-defaults.ts
+++ b/src/modules/common/utils/lesson-defaults.ts
@@ -1,0 +1,25 @@
+import { Lesson } from '../schemas/lesson.schema';
+import { LessonDifficulty, LessonType } from '../types/content';
+
+export type LessonDefaults = {
+  type: LessonType;
+  difficulty: LessonDifficulty;
+  hasAudio: boolean;
+  hasVideo: boolean;
+  xpReward: number;
+  estimatedMinutes: number;
+};
+
+export const normalizeLessonDefaults = (
+  lesson: Pick<
+    Lesson,
+    'type' | 'difficulty' | 'hasAudio' | 'hasVideo' | 'xpReward' | 'estimatedMinutes'
+  >
+): LessonDefaults => ({
+  type: lesson.type ?? 'vocabulary',
+  difficulty: lesson.difficulty ?? 'easy',
+  hasAudio: lesson.hasAudio ?? true,
+  hasVideo: lesson.hasVideo ?? false,
+  xpReward: lesson.xpReward ?? 25,
+  estimatedMinutes: lesson.estimatedMinutes ?? 10,
+});

--- a/src/modules/common/utils/mappers.ts
+++ b/src/modules/common/utils/mappers.ts
@@ -6,6 +6,7 @@ import { UserVocabularyProgress } from '../schemas/user-vocabulary-progress.sche
 import { User } from '../schemas/user.schema';
 import { ModuleItem, LessonItem, LessonProgress, VocabularyItem as VocabType, TaskType, UserVocabularyProgress as UserVocabularyProgressType, VocabularyProgressStats } from '../types/content';
 import { getLocalizedText, SupportedLanguage } from './i18n.util';
+import { normalizeLessonDefaults } from './lesson-defaults';
 
 const STRIP = new Set(['correct','isCorrect','correctIndex','correctIndexes','answer','answers','expected','expectedAnswers','target','targets','solution','solutions']);
 export const redact = (v: any): any =>
@@ -48,19 +49,21 @@ export class LessonMapper {
     progress?: LessonProgress,
     taskTypes?: TaskType[]
   ): LessonItem {
+    const defaults = normalizeLessonDefaults(lesson);
+
     return {
       lessonRef: lesson.lessonRef,
       moduleRef: lesson.moduleRef,
       title: getLocalizedText(lesson.title, language),
       description: getLocalizedText(lesson.description, language),
-      estimatedMinutes: lesson.estimatedMinutes || 10,
+      estimatedMinutes: defaults.estimatedMinutes,
       order: lesson.order || 0,
-      type: lesson.type,
-      difficulty: lesson.difficulty,
+      type: defaults.type,
+      difficulty: defaults.difficulty,
       tags: lesson.tags || [],
-      xpReward: lesson.xpReward || 25,
-      hasAudio: lesson.hasAudio ?? true,
-      hasVideo: lesson.hasVideo ?? false,
+      xpReward: defaults.xpReward,
+      hasAudio: defaults.hasAudio,
+      hasVideo: defaults.hasVideo,
       previewText: lesson.previewText,
       taskTypes: taskTypes || lesson.tasks?.map(t => t.type as TaskType) || [],
       progress: progress,

--- a/src/modules/content/__tests__/presenter.spec.ts
+++ b/src/modules/content/__tests__/presenter.spec.ts
@@ -253,6 +253,7 @@ describe('presentLesson', () => {
     expect(result.estimatedMinutes).toBe(10);
     expect(result.type).toBe('vocabulary');
     expect(result.difficulty).toBe('easy');
+    expect(result.xpReward).toBe(25);
     expect(result.hasAudio).toBe(true);
     expect(result.hasVideo).toBe(false);
     expect(result.progress).toEqual({

--- a/src/modules/content/presenter.ts
+++ b/src/modules/content/presenter.ts
@@ -4,6 +4,7 @@ import { CourseModule } from '../common/schemas/course-module.schema';
 import { UserLessonProgress } from '../common/schemas/user-lesson-progress.schema';
 import { LessonItem, ModuleItem, TaskType } from '../common/types/content';
 import { getLocalizedText } from '../common/utils/i18n.util';
+import { normalizeLessonDefaults } from '../common/utils/lesson-defaults';
 
 const choose = (mt: unknown, lang: string) => getLocalizedText(
   mt as any,
@@ -39,19 +40,21 @@ export function presentLesson(
   }>
 ): LessonItem {
   const taskTypes: TaskType[] = (doc.tasks || []).map(t => t.type as TaskType);
+  const defaults = normalizeLessonDefaults(doc);
+
   return {
     lessonRef: doc.lessonRef,
     moduleRef: doc.moduleRef,
     title: choose(doc.title, lang),
     description: choose(doc.description, lang),
-    estimatedMinutes: doc.estimatedMinutes ?? 10,
+    estimatedMinutes: defaults.estimatedMinutes,
     order: doc.order ?? 0,
-    type: doc.type || 'vocabulary',
-    difficulty: doc.difficulty || 'easy',
+    type: defaults.type,
+    difficulty: defaults.difficulty,
     tags: doc.tags || [],
-    xpReward: doc.xpReward ?? 25,
-    hasAudio: doc.hasAudio !== false,
-    hasVideo: !!doc.hasVideo,
+    xpReward: defaults.xpReward,
+    hasAudio: defaults.hasAudio,
+    hasVideo: defaults.hasVideo,
     previewText: doc.previewText,
     taskTypes,
     progress: progress && {


### PR DESCRIPTION
### Motivation
- Исключить рассинхронизацию дефолтов урока между маппером и презентером. 
- Сконцентрировать логику по умолчанию в одном месте для удобства поддержки и тестирования. 
- Зафиксировать ожидаемое поведение через тесты. 

### Description
- Добавлен общий helper `normalizeLessonDefaults` в `src/modules/common/utils/lesson-defaults.ts` для нормализации полей урока. 
- `LessonMapper.toDto` и `presentLesson` теперь используют `normalizeLessonDefaults` для полей `type`, `difficulty`, `hasAudio`, `hasVideo`, `xpReward` и `estimatedMinutes`. 
- Обновлены тесты в `src/modules/common/__tests__/mappers.spec.ts` и `src/modules/content/__tests__/presenter.spec.ts`, чтобы ожидать одинаковые дефолтные значения. 

### Testing
- Запущены тесты: `npm test -- src/modules/common/__tests__/mappers.spec.ts src/modules/content/__tests__/presenter.spec.ts`. 
- Все указанные тесты прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695193c699ec8320889de7038c67fb96)