### PR TITLE
Проверка задач для опубликованных уроков

### DIFF
--- a/src/modules/content/__tests__/admin-content.controller.spec.ts
+++ b/src/modules/content/__tests__/admin-content.controller.spec.ts
@@ -527,6 +527,21 @@ describe('AdminContentController', () => {
       expect(mockContentService.createLesson).not.toHaveBeenCalled();
     });
 
+    it('should return 400 when published lesson has no tasks', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/admin/content/lessons')
+        .send({
+          ...validLesson,
+          published: true,
+          tasks: [],
+        })
+        .expect(400);
+
+      expect(response.body.message).toBe('Lesson tasks validation failed');
+      expect(response.body.errors).toEqual(expect.arrayContaining(['published lesson requires tasks']));
+      expect(mockContentService.createLesson).not.toHaveBeenCalled();
+    });
+
     it('should create lesson when lint passes', async () => {
       mockContentService.createLesson.mockResolvedValue({ _id: 'lesson-id' });
 

--- a/src/modules/content/__tests__/task-lint.spec.ts
+++ b/src/modules/content/__tests__/task-lint.spec.ts
@@ -50,4 +50,10 @@ describe('lintLessonTasks', () => {
 
     expect(errors).toEqual(expect.arrayContaining(['lessonRef must match a0.travel.NNN']));
   });
+
+  it('should require tasks when published', () => {
+    const errors = lintLessonTasks('a0.basics.001', undefined, 'a0.basics', true);
+
+    expect(errors).toEqual(expect.arrayContaining(['published lesson requires tasks']));
+  });
 });

--- a/src/modules/content/admin-content.controller.ts
+++ b/src/modules/content/admin-content.controller.ts
@@ -38,7 +38,7 @@ export class AdminContentController {
   // Lessons
   @Post('lessons')
   async createLesson(@Body() body: CreateLessonDto) {
-    const errors = lintLessonTasks(body.lessonRef, body.tasks, body.moduleRef);
+    const errors = lintLessonTasks(body.lessonRef, body.tasks, body.moduleRef, body.published);
     if (errors.length) {
       throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }
@@ -54,7 +54,7 @@ export class AdminContentController {
 
   @Patch('lessons/:lessonRef')
   async updateLesson(@Param('lessonRef') lessonRef: string, @Body() body: UpdateLessonDto) {
-    const errors = lintLessonTasks(lessonRef, body.tasks, body.moduleRef);
+    const errors = lintLessonTasks(lessonRef, body.tasks, body.moduleRef, body.published);
     if (errors.length) {
       throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }

--- a/src/modules/content/utils/task-lint.ts
+++ b/src/modules/content/utils/task-lint.ts
@@ -3,13 +3,22 @@ import { TaskDto } from '../dto/task-data.dto';
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
 
-export function lintLessonTasks(lessonRef: string, tasks?: TaskDto[], moduleRef?: string): string[] {
+export function lintLessonTasks(
+  lessonRef: string,
+  tasks?: TaskDto[],
+  moduleRef?: string,
+  published?: boolean
+): string[] {
   const errors: string[] = [];
   if (moduleRef) {
     const pattern = new RegExp(`^${escapeRegExp(moduleRef)}\\.\\d{3}$`);
     if (!pattern.test(lessonRef)) {
       errors.push(`lessonRef must match ${moduleRef}.NNN`);
     }
+  }
+  if (published === true && (!tasks || tasks.length === 0)) {
+    errors.push('published lesson requires tasks');
+    return errors;
   }
   if (!tasks || tasks.length === 0) return errors;
   const seen = new Set<string>();


### PR DESCRIPTION
### Motivation
- Добавлена проверка, что опубликованные уроки не проходят валидацию без заданий (`published === true` требует непустой `tasks`).
- Это предотвращает публикацию пустых уроков без упражнений, что нарушает целостность контента.

### Description
- В `lintLessonTasks` добавлен параметр `published` и логика, которая при `published === true` и пустых/отсутствующих `tasks` добавляет ошибку `published lesson requires tasks`.
- Вызовы `lintLessonTasks` в `admin-content.controller.ts` для `createLesson` и `updateLesson` обновлены так, чтобы прокидывать `body.published` в линтер.
- Обновлены тесты: в `src/modules/content/__tests__/task-lint.spec.ts` добавлен кейс для проверка требования задач при `published`, а в `src/modules/content/__tests__/admin-content.controller.spec.ts` добавлен тест, который ожидает 400 при `published: true` и пустом `tasks`.
- Как проверить локально: запустить `npm test -- src/modules/content/__tests__/task-lint.spec.ts` и `npm test -- src/modules/content/__tests__/admin-content.controller.spec.ts`.

### Testing
- Автоматические unit-тесты не запускались в ходе этого изменения.
- Модифицированные тесты добавлены в кодовую базу и ожидаются для выполнения при CI/локальном запуске тестов.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951949f433c8320929d2d135bd66eff)