### PR TITLE
Фолбэк прогресса v2 и улучшенный бэкфилл moduleRef

### DIFF
--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -123,7 +123,12 @@ export class ContentV2Controller {
     }
 
     const lessons = await this.lessonModel.find({ moduleRef, published: true }).sort({ order: 1 }).lean();
-    const progresses = await this.progressModel.find({ userId: String(userId), moduleRef }).lean();
+    let progresses = await this.progressModel.find({ userId: String(userId), moduleRef }).lean();
+    if (!progresses.length) {
+      progresses = await this.progressModel
+        .find({ userId: String(userId), lessonRef: { $regex: `^${moduleRef}\\.` } })
+        .lean();
+    }
 
     const progressMap = new Map(progresses.map((p: any) => [p.lessonRef, p]));
     return lessons.map(l => presentLesson(l as any, lang, progressMap.get(l.lessonRef)));


### PR DESCRIPTION
### Motivation
- Старые записи в `user_lesson_progress` без поля `moduleRef` не отображали прогресс в v2-эндпоинтах.
- Нужно восстановить корректное отображение прогресса для таких записей и обеспечить надёжный бэкфилл.
- Добавление теста гарантирует, что поведение фолбэка не регрессирует при дальнейшем рефакторинге.

### Description
- В `ContentV2Controller.getLessons` добавлен фолбэк: если запрос прогресса по `{ userId, moduleRef }` возвращает пустой массив, выполняется второй запрос по `{ userId, lessonRef: { $regex: `^${moduleRef}\\.` } }` и результаты используются для отображения прогресса.
- Скрипт `scripts/denormalize-module-ref.ts` обновлён, чтобы находить документы с отсутствующим/`null`/пустым `moduleRef` и вычислять `moduleRef` через разбиение `lessonRef` на части (первые два сегмента) с использованием агрегатного `$set` выражения.
- Добавлен тест в `src/modules/content/__tests__/content-v2.controller.spec.ts`, который проверяет поведение фолбэка (первый вызов возвращает пусто, второй — результаты по `lessonRef`-регекспу).
- `ProgressService.recordTaskAttempt` по-прежнему денормализует и записывает `moduleRef` при создании новых записей, изменений не требует.

### Testing
- Добавлен unit-тест для `GET /content/v2/modules/:moduleRef/lessons` с проверкой фолбэка в `content-v2.controller.spec.ts`.
- Во время этого PR автоматические тесты не выполнялись, поэтому статуса выполнения тестов нет.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695199ec81f083208d3177593a27690a)