### PR TITLE
Добавил timeSpent в прогресс уроков

### DIFF
--- a/src/modules/content/__tests__/content.controller.spec.ts
+++ b/src/modules/content/__tests__/content.controller.spec.ts
@@ -106,6 +106,7 @@ describe('ContentController', () => {
           score: 0.9,
           attempts: 2,
           completedAt,
+          timeSpent: 135,
         },
       ];
 
@@ -131,7 +132,7 @@ describe('ContentController', () => {
             score: 0.9,
             attempts: 2,
             completedAt: completedAt.toISOString(),
-            timeSpent: 0,
+            timeSpent: 135,
           },
         })
       );

--- a/src/modules/content/content.controller.ts
+++ b/src/modules/content/content.controller.ts
@@ -132,6 +132,7 @@ export class ContentController {
           score: (p as any).score || 0,
           attempts: (p as any).attempts || 0,
           completedAt: (p as any).completedAt,
+          timeSpent: (p as any).timeSpent || 0,
         });
       }
 


### PR DESCRIPTION
### Motivation
- Передать `timeSpent` из записи `UserLessonProgress` в ответ API для уроков, чтобы клиент получал реальное время обучения.
- Убедиться, что DTO для прогресса урока содержит корректное значение `timeSpent`, так как оно уже читается в `LessonProgressMapper.toDto`.

### Description
- В `src/modules/content/content.controller.ts` при сборе `progressMap` добавлено поле `timeSpent: (p as any).timeSpent || 0`.
- Обновлён тест `src/modules/content/__tests__/content.controller.spec.ts`, где в мок-прогрессе добавлено `timeSpent: 135` и ожидается это значение в ответе.
- Маппер `LessonProgressMapper.toDto` оставлен без изменений, поскольку он уже возвращает `timeSpent` из входного объекта.

### Testing
- Запущен тестовый файл командой `npx jest src/modules/content/__tests__/content.controller.spec.ts`.
- Тестовый набор выполнился успешно: `PASS` и все тесты в файле прошли (7 тестов).
- Локальные unit-тесты подтвердили корректную передачу `progress.timeSpent` в ответе контроллера.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69519ab86b408320a6e441826b6d0f83)