### PR TITLE
Исправить обработку ошибок submitAnswer

### DIFF
--- a/src/modules/progress/__tests__/progress.controller.spec.ts
+++ b/src/modules/progress/__tests__/progress.controller.spec.ts
@@ -1,0 +1,44 @@
+import { BadRequestException } from '@nestjs/common';
+import { ProgressController } from '../progress.controller';
+import { ProgressService } from '../progress.service';
+import { AnswerValidatorService } from '../answer-validator.service';
+import { SubmitAnswerDto } from '../dto/submit-answer.dto';
+
+describe('ProgressController', () => {
+  it('should throw BadRequestException with validator error message', async () => {
+    const mockProgressService = {
+      recordTaskAttempt: jest.fn(),
+    } as unknown as ProgressService;
+    const mockValidatorService = {
+      validateAnswer: jest.fn().mockRejectedValue(new Error('Lesson not found')),
+    } as unknown as AnswerValidatorService;
+
+    const controller = new ProgressController(
+      mockProgressService,
+      mockValidatorService,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const body: SubmitAnswerDto = {
+      lessonRef: 'a0.test.lesson',
+      taskRef: 'a0.test.lesson.t1',
+      userAnswer: 'answer',
+    };
+
+    try {
+      await controller.submitAnswer('idempotency-key', body, { user: { userId: 'user-1' } });
+      fail('Ожидалось исключение BadRequestException');
+    } catch (error) {
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect((error as BadRequestException).getStatus()).toBe(400);
+      const response = (error as BadRequestException).getResponse();
+      if (typeof response === 'string') {
+        expect(response).toBe('Lesson not found');
+      } else {
+        expect(response).toMatchObject({ message: 'Lesson not found' });
+      }
+    }
+  });
+});

--- a/src/modules/progress/progress.controller.ts
+++ b/src/modules/progress/progress.controller.ts
@@ -84,11 +84,11 @@ export class ProgressController {
       };
     } catch (error) {
       console.error('Answer validation error:', error);
-      return {
-        isCorrect: false,
-        score: 0,
-        feedback: 'An error occurred while checking your answer',
-      };
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new BadRequestException(message);
     }
   }
 
@@ -174,4 +174,3 @@ export class ProgressController {
     return { items };
   }
 }
-


### PR DESCRIPTION
### Motivation
- Клиент должен получать корректный HTTP-статус и причину ошибки вместо неинформативного JSON-ответа.
- Текущая реализация возвращала вспомогательный объект в `catch`, что маскировало реальные ошибки (например, `Lesson not found`).
- Нужно пробрасывать `BadRequestException` с оригинальным сообщением для корректной обработки на клиенте.
- Добавить тест, который проверяет, что при ошибке валидатора возвращается статус 400 и сообщение ошибки.

### Description
- В `src/modules/progress/progress.controller.ts` в методе `submitAnswer` в блоке `catch` логируем ошибку и если это `BadRequestException` — пробрасываем её дальше, иначе создаём и бросаем `BadRequestException` с сообщением исходной ошибки.
- Сохранено поведение логирования через `console.error` для облегчения отладки.
- Добавлен тест `src/modules/progress/__tests__/progress.controller.spec.ts`, который мокает `AnswerValidatorService` чтобы отклонять с `Error('Lesson not found')` и проверяет, что контроллер бросает `BadRequestException` с корректным статусом и сообщением.
- Обновлён импорт `BadRequestException` и подключены необходимые тестовые заглушки для `ProgressService` и `AnswerValidatorService`.

### Testing
- Запущен единичный тест `npx jest src/modules/progress/__tests__/progress.controller.spec.ts` и он прошёл успешно.
- Тест-спецификация проверяет, что при ошибке валидатора контроллер бросает `BadRequestException` со статусом `400` и сообщением `Lesson not found`.
- Локальные тесты: `1 passed, 1 total` (соответствующий тестовый файл).
- Дополнительных автоматизированных тестов не запускалось.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a5a5b434832081e64ec0746f7652)