### PR TITLE
Привёл формат ответа уроков v2 к { lessons: [...] }

### DIFF
--- a/src/modules/content/__tests__/content-v2.controller.spec.ts
+++ b/src/modules/content/__tests__/content-v2.controller.spec.ts
@@ -129,12 +129,14 @@ describe('ContentV2Controller', () => {
         .get('/content/v2/modules/a0.basics/lessons?lang=ru')
         .expect(200);
 
-      expect(response.body).toEqual([
-        expect.objectContaining({
-          lessonRef: 'a0.basics.001',
-          progress: expect.objectContaining({ status: 'in_progress' }),
-        }),
-      ]);
+      expect(response.body).toEqual({
+        lessons: [
+          expect.objectContaining({
+            lessonRef: 'a0.basics.001',
+            progress: expect.objectContaining({ status: 'in_progress' }),
+          }),
+        ],
+      });
     });
 
     it('should fallback to lessonRef regex when moduleRef progress is missing', async () => {
@@ -171,12 +173,14 @@ describe('ContentV2Controller', () => {
         userId: 'user-1',
         lessonRef: { $regex: '^a0.basics\\.' },
       });
-      expect(response.body).toEqual([
-        expect.objectContaining({
-          lessonRef: 'a0.basics.001',
-          progress: expect.objectContaining({ status: 'completed' }),
-        }),
-      ]);
+      expect(response.body).toEqual({
+        lessons: [
+          expect.objectContaining({
+            lessonRef: 'a0.basics.001',
+            progress: expect.objectContaining({ status: 'completed' }),
+          }),
+        ],
+      });
     });
   });
 

--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -131,7 +131,7 @@ export class ContentV2Controller {
     }
 
     const progressMap = new Map(progresses.map((p: any) => [p.lessonRef, p]));
-    return lessons.map(l => presentLesson(l as any, lang, progressMap.get(l.lessonRef)));
+    return { lessons: lessons.map(l => presentLesson(l as any, lang, progressMap.get(l.lessonRef))) };
   }
 
   @Get('lessons/:lessonRef')


### PR DESCRIPTION
### Motivation
- Привести формат ответа `GET /content/v2/modules/:moduleRef/lessons` в соответствие с v1 и сделать его объектом `{ lessons: [...] }`.
- Сохранить содержимое массива уроков без изменений, только обернуть в объект для консистентности API.

### Description
- В `src/modules/content/content-v2.controller.ts` метод `getLessons` теперь возвращает `{ lessons: [...] }` вместо массива.
- Обновлены ожидания в тесте `src/modules/content/__tests__/content-v2.controller.spec.ts` под новый формат ответа.
- Логика формирования уроков и сопоставления прогресса пользователя не изменилась; изменён только формат обёртки.

### Testing
- Юнит-тест `src/modules/content/__tests__/content-v2.controller.spec.ts` был обновлён для проверки нового формата ответа.
- Автоматические тесты не запускались в рамках этого изменения; для проверки запустите `npm test -- content-v2.controller.spec.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a81893d08320a5bf5b01225fbcd5)