### PR TITLE
Уточнил lint-проверки задач контента

### DIFF
--- a/src/modules/content/__tests__/task-lint.spec.ts
+++ b/src/modules/content/__tests__/task-lint.spec.ts
@@ -56,4 +56,33 @@ describe('lintLessonTasks', () => {
 
     expect(errors).toEqual(expect.arrayContaining(['published lesson requires tasks']));
   });
+
+  it('should validate speak prompt and listen audioKey trimming', () => {
+    const errors = lintLessonTasks('a0.basics.001', [
+      { ref: 'a0.basics.001.t1', type: 'speak', data: { prompt: '   ' } },
+      { ref: 'a0.basics.001.t2', type: 'listen', data: { audioKey: ' audio.key ' } },
+    ] as any);
+
+    expect(errors).toEqual(
+      expect.arrayContaining(['speak[0].prompt is required', 'listen[1].audioKey is required'])
+    );
+  });
+
+  it('should validate flashcard front/back as non-empty strings', () => {
+    const errors = lintLessonTasks('a0.basics.001', [
+      { ref: 'a0.basics.001.t1', type: 'flashcard', data: { front: '', back: '   ' } },
+    ] as any);
+
+    expect(errors).toEqual(expect.arrayContaining(['flashcard[0].front/back are required']));
+  });
+
+  it('should accept valid speak, listen, and flashcard tasks', () => {
+    const errors = lintLessonTasks('a0.basics.001', [
+      { ref: 'a0.basics.001.t1', type: 'speak', data: { prompt: 'Say hello' } },
+      { ref: 'a0.basics.001.t2', type: 'listening', data: { audioKey: 'a0.basics.001.t2' } },
+      { ref: 'a0.basics.001.t3', type: 'flashcard', data: { front: 'Hello', back: 'Привет' } },
+    ] as any);
+
+    expect(errors).toEqual([]);
+  });
 });

--- a/src/modules/content/utils/task-lint.ts
+++ b/src/modules/content/utils/task-lint.ts
@@ -2,6 +2,8 @@ import { TaskDto } from '../dto/task-data.dto';
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
+const isTrimmedNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0 && value.trim() === value;
 
 export function lintLessonTasks(
   lessonRef: string,
@@ -59,13 +61,17 @@ export function lintLessonTasks(
     }
     if (t.type === 'listen' || t.type === 'listening') {
       const d = t.data as any;
-      if (!isNonEmptyString(d.audioKey)) errors.push(`${t.type}[${i}].audioKey is required`);
+      if (!isTrimmedNonEmptyString(d.audioKey)) errors.push(`${t.type}[${i}].audioKey is required`);
     }
     if (t.type === 'flashcard') {
       const d = t.data as any;
       if (!isNonEmptyString(d.front) || !isNonEmptyString(d.back)) {
         errors.push(`flashcard[${i}].front/back are required`);
       }
+    }
+    if (t.type === 'speak') {
+      const d = t.data as any;
+      if (!isNonEmptyString(d.prompt)) errors.push(`speak[${i}].prompt is required`);
     }
   });
   return errors;


### PR DESCRIPTION
### Motivation
- Синхронизировать локальные lint-проверки с ожиданиями DTO и избежать пропуска пустых или необрезанных строк.
- Гарантировать, что у `speak` есть непустой `prompt` и у `listen`/`listening` `audioKey` не содержит пробелов по краям.
- Убедиться, что у `flashcard` поля `front`/`back` — непустые строки, а не только присутствуют.
- Снизить вероятность багов из-за некорректных данных задач при раннем обнаружении ошибок.

### Description
- Добавлен хелпер `isTrimmedNonEmptyString` и применён для валидации `audioKey` в `listen`/`listening` в `lintLessonTasks`.
- Добавлена проверка непустого `prompt` для задач типа `speak` в `src/modules/content/utils/task-lint.ts`.
- Сохранена/уточнена проверка `flashcard.front` и `flashcard.back` через `isNonEmptyString` в `lintLessonTasks` для соответствия `FlashcardTaskDataDto`.
- Добавлены и обновлены тесты в `src/modules/content/__tests__/task-lint.spec.ts` с негативными и позитивными кейсами для `speak`, `listen`/`listening` и `flashcard`.

### Testing
- Автоматические unit-тесты для изменённого кода не запускались в рамках этого изменения.
- Чтобы проверить локально, запустить: `npm test -- src/modules/content/__tests__/task-lint.spec.ts`.
- Новые тесты покрывают негативные кейсы с пустыми/обрезанными строками и позитивные примеры без ошибок.
- Нет миграций и изменений, влияющих на API или БД.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a89f6ff083208c2f8db1aae021ef)