### PR TITLE
Проверка задач при публикации урока в админке

### DIFF
--- a/src/modules/content/__tests__/admin-content.controller.spec.ts
+++ b/src/modules/content/__tests__/admin-content.controller.spec.ts
@@ -26,6 +26,7 @@ describe('AdminContentController', () => {
     updateModule: jest.fn(),
     createLesson: jest.fn(),
     listLessons: jest.fn(),
+    getLessonByRef: jest.fn(),
     updateLesson: jest.fn(),
   };
 
@@ -600,6 +601,30 @@ describe('AdminContentController', () => {
         'a0.basics.001',
         expect.objectContaining({ tasks: expect.any(Array) })
       );
+    });
+
+    it('should allow publish without tasks by using tasks from db', async () => {
+      mockContentService.getLessonByRef.mockResolvedValue({
+        lessonRef: 'a0.basics.001',
+        moduleRef: 'a0.basics',
+        tasks: [
+          {
+            ref: 'a0.basics.001.t1',
+            type: 'gap',
+            data: { text: 'It costs ____ dollars', answer: '10' },
+          },
+        ],
+      });
+      mockContentService.updateLesson.mockResolvedValue({ ok: true });
+
+      const response = await request(app.getHttpServer())
+        .patch('/admin/content/lessons/a0.basics.001')
+        .send({ published: true })
+        .expect(200);
+
+      expect(response.body).toEqual({ ok: true });
+      expect(mockContentService.getLessonByRef).toHaveBeenCalledWith('a0.basics.001');
+      expect(mockContentService.updateLesson).toHaveBeenCalledWith('a0.basics.001', { published: true });
     });
   });
 });

--- a/src/modules/content/admin-content.controller.ts
+++ b/src/modules/content/admin-content.controller.ts
@@ -54,7 +54,18 @@ export class AdminContentController {
 
   @Patch('lessons/:lessonRef')
   async updateLesson(@Param('lessonRef') lessonRef: string, @Body() body: UpdateLessonDto) {
-    const errors = lintLessonTasks(lessonRef, body.tasks, body.moduleRef, body.published);
+    let tasksForLint = body.tasks;
+    let moduleRefForLint = body.moduleRef;
+
+    if (body.published === true) {
+      const currentLesson = await this.content.getLessonByRef(lessonRef);
+      if (currentLesson) {
+        if (!tasksForLint) tasksForLint = currentLesson.tasks;
+        if (!moduleRefForLint) moduleRefForLint = currentLesson.moduleRef;
+      }
+    }
+
+    const errors = lintLessonTasks(lessonRef, tasksForLint, moduleRefForLint, body.published);
     if (errors.length) {
       throw new BadRequestException({ message: 'Lesson tasks validation failed', errors });
     }

--- a/src/modules/content/content.service.ts
+++ b/src/modules/content/content.service.ts
@@ -56,6 +56,10 @@ export class ContentService {
     return this.lessonModel.find(q).sort({ moduleRef: 1, order: 1 }).lean();
   }
 
+  async getLessonByRef(lessonRef: string) {
+    return this.lessonModel.findOne({ lessonRef }).lean();
+  }
+
   async updateLesson(lessonRef: string, update: UpdateLessonInput) {
     const nextUpdate = { ...update } as Partial<Lesson>;
     if (update.tasks) {


### PR DESCRIPTION
### Motivation
- Валидировать публикацию урока на основании реальных задач, когда клиент не присылает `tasks` в PATCH-запросе.
- Избежать ошибок при публикации пустых уроков и обеспечить согласованность с текущим состоянием БД.

### Description
- В `AdminContentController.updateLesson` перед вызовом `lintLessonTasks` при `published === true` подгружается текущий урок через `content.getLessonByRef` и, при отсутствии `body.tasks` или `body.moduleRef`, используются значения из БД для валидации.
- Добавлен метод `ContentService.getLessonByRef(lessonRef: string)` для получения урока из БД.
- Обновлены тесты: добавлен тест в `src/modules/content/__tests__/admin-content.controller.spec.ts` на PATCH с `published=true` без `tasks`, и мок `getLessonByRef` добавлен в `mockContentService`.

### Testing
- Добавлен unit-тест `src/modules/content/__tests__/admin-content.controller.spec.ts` на сценарий публикации урока без `tasks` (использование задач из БД).
- В рамках этого изменения автоматические тесты не запускались.
- Для запуска соответствующего набора тестов выполнить `npm test -- src/modules/content/__tests__/admin-content.controller.spec.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b2284c9883209078118634ecb820)