### PR TITLE
Валидация moduleRef через DTO для контента

### DIFF
--- a/src/modules/content/__tests__/content.controller.spec.ts
+++ b/src/modules/content/__tests__/content.controller.spec.ts
@@ -143,7 +143,9 @@ describe('ContentController', () => {
         .get('/content/lessons?moduleRef=invalid-module')
         .expect(400);
 
-      expect(response.body.message).toBe('Invalid moduleRef format');
+      expect(response.body.message).toEqual(
+        expect.arrayContaining([expect.stringContaining('moduleRef')])
+      );
     });
 
     it('should filter lessons by moduleRef', async () => {

--- a/src/modules/content/content.controller.ts
+++ b/src/modules/content/content.controller.ts
@@ -107,10 +107,6 @@ export class ContentController {
     const language = parseLanguage(lang);
     const filter: any = { published: true };
     if (moduleRef) {
-      // 🔒 БАЗОВАЯ ВАЛИДАЦИЯ moduleRef
-      if (!/^[a-z0-9]+\.[a-z0-9_]+$/.test(moduleRef)) {
-        throw new BadRequestException('Invalid moduleRef format');
-      }
       filter.moduleRef = moduleRef;
     }
     

--- a/src/modules/content/dto/get-content.dto.ts
+++ b/src/modules/content/dto/get-content.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsEnum, Length, IsInt, Min } from 'class-validator';
+import { IsString, IsOptional, IsEnum, Length, IsInt, Min, Matches } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class GetModulesDto {
@@ -26,6 +26,7 @@ export class GetModulesDto {
 export class GetLessonsDto {
   @IsOptional()
   @IsString()
+  @Matches(/^[a-z0-9]+\.[a-z0-9_]+$/)
   moduleRef?: string;
 
   @IsOptional()


### PR DESCRIPTION
### Motivation
- Перенести валидацию параметра `moduleRef` в DTO, чтобы использовать механизмы `ValidationPipe` и держать валидацию централизованной.
- Упростить контроллер, убрав ручную проверку формата и исключения за пределами DTO.
- Сделать тесты менее хрупкими к формату сообщения ошибки валидации.

### Description
- Добавлен декоратор `@Matches(/^[a-z0-9]+\.[a-z0-9_]+$/)` и импорт `Matches` в `GetLessonsDto` в файле `src/modules/content/dto/get-content.dto.ts`.
- Удалена ручная проверка `if (!/^[a-z0-9]+\.[a-z0-9_]+$/.test(moduleRef)) { throw new BadRequestException(...) }` из `ContentController.getLessons` в `src/modules/content/content.controller.ts`.
- Обновлён тест `src/modules/content/__tests__/content.controller.spec.ts`, теперь он ожидает, что поле ошибки содержит `moduleRef` вместо точного сообщения `Invalid moduleRef format`.

### Testing
- Обновлён модульный тест `src/modules/content/__tests__/content.controller.spec.ts` под новую форму ошибки валидации.
- Автоматический запуск тестов (`jest`) не выполнялся для этого изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b445d1ec83208524f89339cf0729)