### PR TITLE
Подключение prerequisite guard к урокам v2

### DIFF
--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -10,6 +10,7 @@ import { LessonMapper } from '../common/utils/mappers';
 import { parseLanguage } from '../common/utils/i18n.util';
 import { presentLesson, presentModule } from './presenter';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { LessonPrerequisiteGuard } from './guards/lesson-prerequisite.guard';
 import { GetModulesDto } from './dto/get-content.dto';
 
 @Controller('content/v2')
@@ -135,6 +136,7 @@ export class ContentV2Controller {
   }
 
   @Get('lessons/:lessonRef')
+  @UseGuards(JwtAuthGuard, LessonPrerequisiteGuard)
   async getLesson(@Param('lessonRef') lessonRef: string, @Query('lang') lang = 'ru', @Request() req: any) {
     const userId = req.user?.userId; // Get userId from JWT token
     if (!userId) {


### PR DESCRIPTION
### Motivation
- Обеспечить единые правила доступа к урокам в версии v2 через существующий `LessonPrerequisiteGuard`.
- Привести формат ошибок для проверок предварительных условий в v2 к тому же виду, что и в v1 (BadRequest/Forbidden).
- Сделать поведение эндпоинта `GET /content/v2/lessons/:lessonRef` согласованным с контроллером v1.

### Description
- Подключён импорт `LessonPrerequisiteGuard` и добавлен декоратор `@UseGuards(JwtAuthGuard, LessonPrerequisiteGuard)` на эндпоинт `GET /content/v2/lessons/:lessonRef` в `src/modules/content/content-v2.controller.ts`.
- Обновлены тесты в `src/modules/content/__tests__/content-v2.controller.spec.ts`: добавлен мок `ContentService`, зарегистрирован `LessonPrerequisiteGuard` и добавлены сценарии, проверяющие вызов guard и соответствие формата ошибок (400/403) при разных результатах `canStartLesson`.
- Тесты проверяют, что guard получает `lessonRef` из `params` и `userId` из `request.user` посредством ожидания вызова `mockContentService.canStartLesson` с правильными аргументами.

### Testing
- Запуск: `npx jest src/modules/content/__tests__/content-v2.controller.spec.ts`.
- Результат: все тесты в файле прошли успешно (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951be08c7688320833711b8a4b414d2)