### PR TITLE
Уточнить форматы ответов и сообщения ошибок для progress

### DIFF
--- a/src/modules/progress/__tests__/answer-validator.service.spec.ts
+++ b/src/modules/progress/__tests__/answer-validator.service.spec.ts
@@ -80,6 +80,21 @@ describe('AnswerValidatorService', () => {
     expect(result.score).toBeGreaterThan(0);
   });
 
+  it('returns a detailed error for invalid order format', async () => {
+    mockLessonModel.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        lessonRef: 'a0.basics.001',
+        tasks: [
+          { ref: 't1', type: 'order', data: { tokens: ['What', 'time', 'is', 'it'] }, validationData: { tokens: ['What', 'time', 'is', 'it'] } },
+        ],
+      }),
+    });
+
+    await expect(service.validateAnswer('a0.basics.001', 't1', 'not-json')).rejects.toThrow(
+      'Неверный формат ответа для order: ожидается JSON-массив строк, например ["What","time","is","it","?"]',
+    );
+  });
+
   it('validates translate answers by similarity', async () => {
     mockLessonModel.findOne.mockReturnValue({
       lean: jest.fn().mockResolvedValue({
@@ -127,5 +142,25 @@ describe('AnswerValidatorService', () => {
 
     expect(listenResult.isCorrect).toBe(true);
     expect(speakResult.isCorrect).toBe(true);
+  });
+
+  it('returns a detailed error for invalid matching format', async () => {
+    mockLessonModel.findOne.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({
+        lessonRef: 'a0.basics.001',
+        tasks: [
+          {
+            ref: 't1',
+            type: 'matching',
+            data: { pairs: [{ left: 'cat', right: 'кот' }] },
+            validationData: { pairs: [{ left: 'cat', right: 'кот' }] },
+          },
+        ],
+      }),
+    });
+
+    await expect(service.validateAnswer('a0.basics.001', 't1', '"not-an-array"')).rejects.toThrow(
+      'Неверный формат ответа для matching: ожидается JSON-массив пар или объектов с left/right.',
+    );
   });
 });

--- a/src/modules/progress/answer-validator.service.ts
+++ b/src/modules/progress/answer-validator.service.ts
@@ -28,8 +28,8 @@ export class TaskNotFoundError extends Error {
 }
 
 export class InvalidAnswerFormatError extends Error {
-  constructor() {
-    super('Invalid answer format');
+  constructor(message = 'Неверный формат ответа') {
+    super(message);
     this.name = 'InvalidAnswerFormatError';
   }
 }
@@ -150,7 +150,7 @@ export class AnswerValidatorService {
         feedback: isCorrect ? 'Perfect!' : 'Check the word order'
       };
     } catch (e) {
-      throw new InvalidAnswerFormatError();
+      throw new InvalidAnswerFormatError('Неверный формат ответа для order: ожидается JSON-массив строк, например ["What","time","is","it","?"]');
     }
   }
 
@@ -206,11 +206,11 @@ export class AnswerValidatorService {
     try {
       parsedAnswer = JSON.parse(userAnswer);
     } catch (e) {
-      throw new InvalidAnswerFormatError();
+      throw new InvalidAnswerFormatError('Неверный формат ответа для matching: ожидается JSON-массив пар или объектов с left/right.');
     }
 
     if (!Array.isArray(parsedAnswer)) {
-      throw new InvalidAnswerFormatError();
+      throw new InvalidAnswerFormatError('Неверный формат ответа для matching: ожидается JSON-массив пар или объектов с left/right.');
     }
 
     const correctMap = new Map(pairs.map(pair => [pair.left, pair.right]));

--- a/src/modules/progress/dto/submit-answer.dto.ts
+++ b/src/modules/progress/dto/submit-answer.dto.ts
@@ -18,8 +18,11 @@ export class SubmitAnswerDto {
   taskRef!: string;
 
   // 🔒 ФРОНТЕНД ОТПРАВЛЯЕТ ТОЛЬКО СВОЙ ОТВЕТ
+  // Примеры: "Hello", "2", "[\"apple\",\"banana\"]"
+  // Для order: "[\"What\",\"time\",\"is\",\"it\",\"?\"]"
+  // Для matching: "[[0,1],[1,0]]" или "[{\"left\":\"cat\",\"right\":\"кот\"}]"
   @IsString()
-  userAnswer!: string; // Например: "Hello", "2", "['apple','banana']"
+  userAnswer!: string;
 
   @IsOptional()
   @IsNumber()

--- a/src/modules/progress/progress.controller.ts
+++ b/src/modules/progress/progress.controller.ts
@@ -15,7 +15,7 @@ const badRequestResponseSchema = {
   type: 'object',
   properties: {
     statusCode: { type: 'number', example: 400 },
-    message: { type: 'string', example: 'Invalid answer format' },
+    message: { type: 'string', example: 'Неверный формат ответа для order: ожидается JSON-массив строк, например ["What","time","is","it","?"]' },
     error: { type: 'string', example: 'Bad Request' },
   },
 };
@@ -68,11 +68,45 @@ export class ProgressController {
 
   // 🔒 НОВЫЙ БЕЗОПАСНЫЙ ЭНДПОИНТ
   @Post('submit-answer')
-  @ApiOperation({ summary: 'Проверить ответ пользователя и сохранить попытку' })
-  @ApiOkResponse({ description: 'Результат проверки и данные попытки.' })
+  @ApiOperation({
+    summary: 'Проверить ответ пользователя и сохранить попытку',
+    description: 'Пример запроса:\n```json\n{\n  "lessonRef": "a0.basics.001",\n  "taskRef": "a0.basics.001.t1",\n  "userAnswer": "[\\"What\\",\\"time\\",\\"is\\",\\"it\\",\\"?\\"]",\n  "durationMs": 1200\n}\n```',
+  })
+  @ApiOkResponse({
+    description: 'Результат проверки и данные попытки.',
+    schema: {
+      type: 'object',
+      properties: {
+        attemptId: { type: 'string', example: '64f9b6a0b3b6c92f4e2a1234' },
+        isCorrect: { type: 'boolean', example: false },
+        score: { type: 'number', example: 0.5 },
+        feedback: { type: 'string', example: 'Check the word order' },
+        correctAnswer: { type: 'string', example: 'What time is it ?' },
+        explanation: { type: 'string', example: 'Порядок слов в вопросе.' },
+      },
+    },
+  })
   @ApiBadRequestResponse({
     description: 'Ошибка валидации ответа.',
     schema: badRequestResponseSchema,
+    examples: {
+      invalidOrderFormat: {
+        summary: 'Неверный формат order',
+        value: {
+          statusCode: 400,
+          message: 'Неверный формат ответа для order: ожидается JSON-массив строк, например ["What","time","is","it","?"]',
+          error: 'Bad Request',
+        },
+      },
+      invalidMatchingFormat: {
+        summary: 'Неверный формат matching',
+        value: {
+          statusCode: 400,
+          message: 'Неверный формат ответа для matching: ожидается JSON-массив пар или объектов с left/right.',
+          error: 'Bad Request',
+        },
+      },
+    },
   })
   @ApiNotFoundResponse({
     description: 'Урок или задание не найдены.',
@@ -135,7 +169,7 @@ export class ProgressController {
       }
 
       if (error instanceof ValidationDataError) {
-        throw new InternalServerErrorException('Internal server error');
+        throw new InternalServerErrorException(error.message);
       }
 
       console.error('Answer validation error:', error);


### PR DESCRIPTION
### Motivation
- Сделать сообщения об ошибках формата более понятными и локализованными для клиентов API.
- Добавить примеры допустимых форматов `userAnswer` для сложных типов заданий (`order`, `matching`).
- Обновить Swagger-документацию, чтобы разработчикам было проще отправлять корректные запросы.

### Description
- Добавлены примеры в комментарии к полю `userAnswer` в `src/modules/progress/dto/submit-answer.dto.ts` (включая `order` и `matching`).
- Изменён класс `InvalidAnswerFormatError` в `src/modules/progress/answer-validator.service.ts` на принимающий сообщение и добавлены детализированные сообщения для типов `order` и `matching`.
- В контроллере `POST /progress/submit-answer` (`src/modules/progress/progress.controller.ts`) возвращается конкретное сообщение ошибки (`error.message`) и добавлены примеры/схемы ответа в декораторах `@ApiOperation`, `@ApiOkResponse` и `@ApiBadRequestResponse`.
- Добавлены/расширены тесты в `src/modules/progress/__tests__/answer-validator.service.spec.ts`, проверяющие детализированные ошибки формата для `order` и `matching`.

### Testing
- Запущена команда `npx jest src/modules/progress/__tests__/answer-validator.service.spec.ts`.
- Тестовый набор `answer-validator.service.spec.ts` прошёл: 1 suite, 8 tests, все успешно.
- Автоматические тесты на добавленные проверки ошибок формата успешно подтверждают новые сообщения об ошибках.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951bf69dffc832095ab6bfe1fff9551)