### PR TITLE
Проверка доступа к урокам при записи попытки

### DIFF
--- a/src/modules/content/content.module.ts
+++ b/src/modules/content/content.module.ts
@@ -31,8 +31,7 @@ import { LessonPrerequisiteGuard } from './guards/lesson-prerequisite.guard';
   ],
   controllers: [ContentController, ContentV2Controller, AdminContentController, VocabularyController],
   providers: [ContentService, VocabularyService, OptionalUserGuard, PublicGuard, LessonPrerequisiteGuard],
-  exports: [VocabularyService],
+  exports: [ContentService, VocabularyService],
 })
 export class ContentModule {}
-
 

--- a/src/modules/progress/progress.module.ts
+++ b/src/modules/progress/progress.module.ts
@@ -13,10 +13,12 @@ import { Achievement, AchievementSchema } from '../common/schemas/achievement.sc
 import { Lesson, LessonSchema } from '../common/schemas/lesson.schema';
 import { AuthModule } from '../auth/auth.module';
 import { SessionCleanupService } from './session-cleanup.service';
+import { ContentModule } from '../content/content.module';
 
 @Module({
   imports: [
     AuthModule,
+    ContentModule,
     MongooseModule.forFeature([
       { name: User.name, schema: UserSchema },
       { name: UserLessonProgress.name, schema: UserLessonProgressSchema },
@@ -33,5 +35,4 @@ import { SessionCleanupService } from './session-cleanup.service';
   exports: [ProgressService],
 })
 export class ProgressModule {}
-
 


### PR DESCRIPTION
### Motivation
- Запретить запись попыток для неопубликованных уроков и вернуть понятную ошибку вместо сохранения данных.
- Обеспечить соблюдение предварительных условий урока через существующую логику `ContentService.canStartLesson`.
- Предотвратить расхождение между контролем доступа в контенте и логикой прогресса.
- Снизить риск нечаянного начисления XP за недоступные уроки.

### Description
- В `recordTaskAttempt` заменён запрос урока на `lessonModel.findOne({ lessonRef: args.lessonRef, published: true })` и при отсутствии урока бросается `BadRequestException('Lesson not found')`.
- Добавлен вызов `ContentService.canStartLesson` и блокировка попытки с `ForbiddenException` при `canStart: false`, а также соответствующая обработка `requiredLesson` в теле ошибки.
- Инъекция `ContentService` в `ProgressService` обеспечена через импорт `ContentModule` в `ProgressModule` и экспорт `ContentService` из `ContentModule`.
- Обновлены импорты/исключения: добавлен `ForbiddenException` и перемещён ранний чек урока перед созданием ULP/attempt.

### Testing
- Автоматические тесты не запускались в рамках этого изменения.
- Рекомендовано выполнить `npm test` / `jest` для проверки регрессий в модульных тестах.
- Ручная проверка при отправке ответа по неопубликованному уроку должна вернуть `400` или `403` в зависимости от причины доступа.
- Проверка сохранения попытки рекомендуется для опубликованных и доступных уроков.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c2431aac83208357932759a02d69)