### PR TITLE
Исправил ошибку при отсутствии expected у translate

### DIFF
--- a/src/modules/progress/__tests__/answer-validator.service.spec.ts
+++ b/src/modules/progress/__tests__/answer-validator.service.spec.ts
@@ -122,7 +122,7 @@ describe('AnswerValidatorService', () => {
     });
 
     await expect(service.validateAnswer('a0.basics.001', 't1', 'Hello')).rejects.toThrow(
-      'Missing expected answers for translate task',
+      'Отсутствуют ожидаемые ответы для translate-задачи',
     );
   });
 

--- a/src/modules/progress/answer-validator.service.ts
+++ b/src/modules/progress/answer-validator.service.ts
@@ -35,8 +35,8 @@ export class InvalidAnswerFormatError extends Error {
 }
 
 export class ValidationDataError extends Error {
-  constructor() {
-    super('Missing validation data');
+  constructor(message = 'Отсутствуют данные для валидации') {
+    super(message);
     this.name = 'ValidationDataError';
   }
 }
@@ -66,7 +66,7 @@ export class AnswerValidatorService {
     if (task.type === 'translate') {
       const expected = (validationData as TranslateValidationData | undefined)?.expected;
       if (!expected?.length) {
-        throw new Error('Missing expected answers for translate task');
+        throw new ValidationDataError('Отсутствуют ожидаемые ответы для translate-задачи');
       }
     }
 


### PR DESCRIPTION
### Motivation
- Убедиться, что при отсутствии `expected` в `translate`-задании выбрасывается корректный тип ошибки, который обрабатывается контроллером.
- Заменить общий `Error` на специализированную ошибку с понятным сообщением для отладки и логов.

### Description
- В `AnswerValidatorService` заменил `throw new Error('Missing expected answers for translate task')` на `throw new ValidationDataError('Отсутствуют ожидаемые ответы для translate-задачи')`.
- Обновил конструктор `ValidationDataError`, чтобы по умолчанию сообщение было на русском: `Отсутствуют данные для валидации`.
- Обновил тест `src/modules/progress/__tests__/answer-validator.service.spec.ts`, ожидающий новое сообщение об ошибке для случая без `expected`.
- Контроллер `progress.controller.ts` не требует изменений, так как он уже обрабатывает `ValidationDataError`.

### Testing
- Запущена единичная тестовая спецификация командой `npx jest src/modules/progress/__tests__/answer-validator.service.spec.ts`.
- Тесты в этом наборе успешно прошли: `1 suite, 8 tests, all passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c2c9bff08320b804f519ea3e57f0)