### PR TITLE
Вынес и унифицировал валидацию lessonRef

### DIFF
--- a/src/modules/common/utils/lesson-ref.ts
+++ b/src/modules/common/utils/lesson-ref.ts
@@ -1,0 +1,12 @@
+const LESSON_REF_REGEX = /^[a-z0-9]+\.[a-z0-9_]+\.\d{3}$/;
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const isValidLessonRef = (lessonRef: unknown): lessonRef is string =>
+  typeof lessonRef === 'string' && LESSON_REF_REGEX.test(lessonRef);
+
+export const matchesModuleRef = (lessonRef: string, moduleRef: string): boolean => {
+  if (!isValidLessonRef(lessonRef) || typeof moduleRef !== 'string') return false;
+  const pattern = new RegExp(`^${escapeRegExp(moduleRef)}\\.\\d{3}$`);
+  return pattern.test(lessonRef);
+};

--- a/src/modules/content/__tests__/lesson.dto.spec.ts
+++ b/src/modules/content/__tests__/lesson.dto.spec.ts
@@ -60,6 +60,13 @@ describe('CreateLessonDto', () => {
     expect(errors.some(e => e.property === 'lessonRef')).toBe(true);
   });
 
+  it('should fail when lessonRef format is invalid', async () => {
+    const dto = plainToInstance(CreateLessonDto, { ...validLesson, lessonRef: 'a0.basics.01' });
+    const errors = await validate(dto);
+
+    expect(errors.some(e => e.property === 'lessonRef')).toBe(true);
+  });
+
   it('should fail when type is invalid', async () => {
     const dto = plainToInstance(CreateLessonDto, { ...validLesson, type: 'speaking' });
     const errors = await validate(dto);

--- a/src/modules/content/__tests__/task-lint.spec.ts
+++ b/src/modules/content/__tests__/task-lint.spec.ts
@@ -51,6 +51,12 @@ describe('lintLessonTasks', () => {
     expect(errors).toEqual(expect.arrayContaining(['lessonRef must match a0.travel.NNN']));
   });
 
+  it('should report lessonRef with invalid format when moduleRef provided', () => {
+    const errors = lintLessonTasks('a0.basics.01', undefined, 'a0.basics');
+
+    expect(errors).toEqual(expect.arrayContaining(['lessonRef must match a0.basics.NNN']));
+  });
+
   it('should require tasks when published', () => {
     const errors = lintLessonTasks('a0.basics.001', undefined, 'a0.basics', true);
 

--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -8,6 +8,7 @@ import { UserLessonProgress, UserLessonProgressDocument } from '../common/schema
 import { User, UserDocument } from '../common/schemas/user.schema';
 import { LessonMapper } from '../common/utils/mappers';
 import { parseLanguage } from '../common/utils/i18n.util';
+import { isValidLessonRef } from '../common/utils/lesson-ref';
 import { presentLesson, presentModule } from './presenter';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { LessonPrerequisiteGuard } from './guards/lesson-prerequisite.guard';
@@ -143,7 +144,7 @@ export class ContentV2Controller {
       throw new BadRequestException('userId is required');
     }
 
-    if (!/^[a-z0-9]+\.[a-z0-9_]+\.\d{3}$/.test(lessonRef)) {
+    if (!isValidLessonRef(lessonRef)) {
       throw new BadRequestException('Invalid lessonRef format');
     }
 

--- a/src/modules/content/content.controller.ts
+++ b/src/modules/content/content.controller.ts
@@ -19,6 +19,7 @@ import { Lesson, LessonDocument } from '../common/schemas/lesson.schema';
 import { User, UserDocument } from '../common/schemas/user.schema';
 import { UserLessonProgress, UserLessonProgressDocument } from '../common/schemas/user-lesson-progress.schema';
 import { getLocalizedText, parseLanguage } from '../common/utils/i18n.util';
+import { isValidLessonRef } from '../common/utils/lesson-ref';
 import { ModuleMapper, LessonMapper, LessonProgressMapper } from '../common/utils/mappers';
 import { GetModulesDto, GetLessonsDto, GetLessonDto } from './dto/get-content.dto';
 import { ContentService } from './content.service';
@@ -153,7 +154,7 @@ export class ContentController {
     const language = parseLanguage(lang);
 
     // 🔒 БАЗОВАЯ ВАЛИДАЦИЯ lessonRef
-    if (!/^[a-z0-9]+\.[a-z0-9_]+\.\d{3}$/.test(lessonRef)) {
+    if (!isValidLessonRef(lessonRef)) {
       throw new BadRequestException('Invalid lessonRef format');
     }
 

--- a/src/modules/content/dto/lesson.dto.ts
+++ b/src/modules/content/dto/lesson.dto.ts
@@ -17,16 +17,14 @@ import {
 import { PartialType } from '@nestjs/mapped-types';
 import { TaskDto } from './task-data.dto';
 import { MultilingualTextDto, OptionalMultilingualTextDto } from './module.dto';
-
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+import { matchesModuleRef } from '../../common/utils/lesson-ref';
 
 @ValidatorConstraint({ name: 'LessonRefMatchesModuleRef', async: false })
 class LessonRefMatchesModuleRefConstraint implements ValidatorConstraintInterface {
   validate(value: string, args: ValidationArguments): boolean {
     const dto = args.object as CreateLessonDto;
     if (typeof value !== 'string' || typeof dto?.moduleRef !== 'string') return false;
-    const pattern = new RegExp(`^${escapeRegExp(dto.moduleRef)}\\.\\d{3}$`);
-    return pattern.test(value);
+    return matchesModuleRef(value, dto.moduleRef);
   }
 
   defaultMessage(args: ValidationArguments): string {

--- a/src/modules/content/utils/task-lint.ts
+++ b/src/modules/content/utils/task-lint.ts
@@ -1,6 +1,5 @@
 import { TaskDto } from '../dto/task-data.dto';
-
-const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+import { matchesModuleRef } from '../../common/utils/lesson-ref';
 const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0;
 const isTrimmedNonEmptyString = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0 && value.trim() === value;
@@ -14,8 +13,7 @@ export function lintLessonTasks(
 ): string[] {
   const errors: string[] = [];
   if (moduleRef) {
-    const pattern = new RegExp(`^${escapeRegExp(moduleRef)}\\.\\d{3}$`);
-    if (!pattern.test(lessonRef)) {
+    if (!matchesModuleRef(lessonRef, moduleRef)) {
       errors.push(`lessonRef must match ${moduleRef}.NNN`);
     }
   }


### PR DESCRIPTION
### Motivation
- Централизация логики валидации `lessonRef` для снижения дублирования в кодовой базе.
- Гарантия использования единого регулярного выражения для формата `level.module.NNN`.
- Упрощение поддержки проверок в DTO, контроллерах и линтере.
- Добавление покрытий на граничные кейсы формата ссылок на уроки.

### Description
- Добавлена утилита `src/modules/common/utils/lesson-ref.ts` с функциями `isValidLessonRef` и `matchesModuleRef`.
- Заменены inline-regex проверки в `CreateLessonDto`, `content.controller.ts`, `content-v2.controller.ts` и `task-lint.ts` на использование новых утилит.
- Сообщения об ошибках сохранены читаемыми (например `Invalid lessonRef format` и `lessonRef must match ...`).
- Добавлены тесты для граничных случаев в `src/modules/content/__tests__/lesson.dto.spec.ts` и `src/modules/content/__tests__/task-lint.spec.ts`.

### Testing
- Добавлены unit-тесты `lesson.dto.spec.ts` и `task-lint.spec.ts` покрывающие новые граничные кейсы.
- Автоматические тесты в ходе этого PR не запускались.
- Для локальной проверки запустить `npm test -- lesson.dto.spec.ts` и `npm test -- task-lint.spec.ts`.
- Риски минимальны, логика проверки сохранена и централизована.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c2f0f8f48320b8467440ed16896c)