### PR TITLE
Объединить выборку прогресса уроков модуля

### DIFF
--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -125,12 +125,12 @@ export class ContentV2Controller {
     }
 
     const lessons = await this.lessonModel.find({ moduleRef, published: true }).sort({ order: 1 }).lean();
-    let progresses = await this.progressModel.find({ userId: String(userId), moduleRef }).lean();
-    if (!progresses.length) {
-      progresses = await this.progressModel
-        .find({ userId: String(userId), lessonRef: { $regex: `^${moduleRef}\\.` } })
-        .lean();
-    }
+    const progresses = await this.progressModel
+      .find({
+        userId: String(userId),
+        $or: [{ moduleRef }, { lessonRef: { $regex: `^${moduleRef}\\.` } }],
+      })
+      .lean();
 
     const progressMap = new Map(progresses.map((p: any) => [p.lessonRef, p]));
     return { lessons: lessons.map(l => presentLesson(l as any, lang, progressMap.get(l.lessonRef))) };


### PR DESCRIPTION
### Motivation
- Обеспечить корректное заполнение `progressMap` и не терять записи прогресса, которые хранятся по `lessonRef`.
- В прежней реализации выполнялся второй запрос только если первый возвращал пусто, что могло приводить к пропускам данных.
- Упростить и оптимизировать логику получения прогресса для `getLessons` одним запросом.
- Избежать рассинхрона данных при отображении прогресса уроков модуля.

### Description
- В файле `src/modules/content/content-v2.controller.ts` в методе `getLessons` заменён двойной запрос на единый `find` с условием `$or`.
- Теперь используется запрос: `this.progressModel.find({ userId: String(userId), $or: [{ moduleRef }, { lessonRef: { $regex: `^${moduleRef}\\.` } }] }).lean()`.
- Сборка `progressMap` остаётся как `new Map(progresses.map(p => [p.lessonRef, p]))`, что гарантирует наличие всех записей по урокам.
- Контракт ответа API не изменялся.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c56af6a08320829fb2311aff33ae)