### PR TITLE
Пропуск обёртки ForbiddenException в submitAnswer

### DIFF
--- a/src/modules/progress/progress.controller.ts
+++ b/src/modules/progress/progress.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Headers, Param, Post, Query, UseGuards, BadRequestException, InternalServerErrorException, NotFoundException, Request } from '@nestjs/common';
+import { Body, Controller, Get, Headers, Param, Post, Query, UseGuards, BadRequestException, ForbiddenException, InternalServerErrorException, NotFoundException, Request } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { ApiBadRequestResponse, ApiInternalServerErrorResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -160,6 +160,10 @@ export class ProgressController {
         explanation: validation.explanation,
       };
     } catch (error) {
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
+
       if (error instanceof LessonNotFoundError || error instanceof TaskNotFoundError) {
         throw new NotFoundException(error.message);
       }


### PR DESCRIPTION
### Motivation
- Сохранить поля `error: 'PREREQ_NOT_MET'`, `requiredLesson` и `currentLesson` в ответе при отказе доступа к уроку.
- Избежать оборачивания `ForbiddenException` в `BadRequestException`, чтобы клиент мог корректно обрабатывать причину отказа.

### Description
- Импортировал `ForbiddenException` в `src/modules/progress/progress.controller.ts` и добавил явную проверку в блоке `catch` метода `submitAnswer`.
- Если пойман `ForbiddenException`, он теперь повторно выбрасывается без обёртки: `if (error instanceof ForbiddenException) { throw error; }`.
- Изменение касается только обработки ошибок в `submitAnswer` и не меняет поведение других ошибок.

### Testing
- Автоматические тесты не запускались.
- Изменение покрывается единичным коммитом в `src/modules/progress/progress.controller.ts` и готово к запуску тестов/проверке через интеграционный вызов эндпоинта `POST /progress/submit-answer`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c569a14c832094312f9e401958fd)