### PR TITLE
Оптимизировал выборку уроков в v2

### DIFF
--- a/src/modules/content/content-v2.controller.ts
+++ b/src/modules/content/content-v2.controller.ts
@@ -124,7 +124,10 @@ export class ContentV2Controller {
       throw new BadRequestException('Invalid moduleRef format');
     }
 
-    const lessons = await this.lessonModel.find({ moduleRef, published: true }).sort({ order: 1 }).lean();
+    const lessons = await this.lessonModel
+      .find({ moduleRef, published: true }, { tasks: 0 })
+      .sort({ order: 1 })
+      .lean();
     const progresses = await this.progressModel
       .find({
         userId: String(userId),

--- a/src/modules/content/presenter.ts
+++ b/src/modules/content/presenter.ts
@@ -39,7 +39,9 @@ export function presentLesson(
     score: number; attempts: number; completedAt?: Date; timeSpent?: number;
   }>
 ): LessonItem {
-  const taskTypes: TaskType[] = (doc.tasks || []).map(t => t.type as TaskType);
+  const taskTypes: TaskType[] = (doc.taskTypes
+    ?? doc.tasks?.map(t => t.type as TaskType)
+    ?? []);
   const defaults = normalizeLessonDefaults(doc);
 
   return {


### PR DESCRIPTION
### Motivation
- Уменьшить объём возвращаемых данных и нагрузку на базу при получении списка уроков.
- Избежать передачи полного массива `tasks` там, где он не нужен, при сохранении информации о типах задач.
- Сделать поведение согласованным с существующими мапперами и тестами.

### Description
- В `getLessons` (`ContentV2Controller`) добавлен projection при `find`: `find({ moduleRef, published: true }, { tasks: 0 })` для исключения поля `tasks` из выборки.
- В `presentLesson` (`presenter.ts`) теперь `taskTypes` берутся из `doc.taskTypes` с резервным вычислением через `doc.tasks?.map(t => t.type as TaskType)` если `taskTypes` отсутствует.
- Изменены файлы: `src/modules/content/content-v2.controller.ts` и `src/modules/content/presenter.ts`.

### Testing
- Автоматические тесты не запускались.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c5f339cc8320903fc9aecb1862a9)