### PR TITLE
Add generated A0 lessons (20 per module) and `seed-lessons` seeder

### DIFF
--- a/scripts/actual/content/A0/a0.basics/lessons.json
+++ b/scripts/actual/content/A0/a0.basics/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.basics.001",
+    "title": {
+      "ru": "Алфавит и звуки",
+      "en": "Alphabet and Sounds"
+    },
+    "description": {
+      "ru": "Алфавит и звуки: базовые фразы и практика.",
+      "en": "Alphabet and Sounds: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Алфавит и звуки"
+  },
+  {
+    "lessonRef": "a0.basics.002",
+    "title": {
+      "ru": "Простые приветствия",
+      "en": "Simple Greetings"
+    },
+    "description": {
+      "ru": "Простые приветствия: базовые фразы и практика.",
+      "en": "Simple Greetings: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Простые приветствия"
+  },
+  {
+    "lessonRef": "a0.basics.003",
+    "title": {
+      "ru": "Прощания",
+      "en": "Goodbyes"
+    },
+    "description": {
+      "ru": "Прощания: базовые фразы и практика.",
+      "en": "Goodbyes: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Прощания"
+  },
+  {
+    "lessonRef": "a0.basics.004",
+    "title": {
+      "ru": "Да/нет и короткие ответы",
+      "en": "Yes/No and Short Answers"
+    },
+    "description": {
+      "ru": "Да/нет и короткие ответы: базовые фразы и практика.",
+      "en": "Yes/No and Short Answers: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Да/нет и короткие ответы"
+  },
+  {
+    "lessonRef": "a0.basics.005",
+    "title": {
+      "ru": "Базовые вопросы: кто/что",
+      "en": "Basic Questions: who/what"
+    },
+    "description": {
+      "ru": "Базовые вопросы: кто/что: базовые фразы и практика.",
+      "en": "Basic Questions: who/what: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Базовые вопросы: кто/что"
+  },
+  {
+    "lessonRef": "a0.basics.006",
+    "title": {
+      "ru": "Числа 1–10",
+      "en": "Numbers 1–10"
+    },
+    "description": {
+      "ru": "Числа 1–10: базовые фразы и практика.",
+      "en": "Numbers 1–10: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Числа 1–10"
+  },
+  {
+    "lessonRef": "a0.basics.007",
+    "title": {
+      "ru": "Цвета",
+      "en": "Colors"
+    },
+    "description": {
+      "ru": "Цвета: базовые фразы и практика.",
+      "en": "Colors: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Цвета"
+  },
+  {
+    "lessonRef": "a0.basics.008",
+    "title": {
+      "ru": "Предметы вокруг",
+      "en": "Objects Around You"
+    },
+    "description": {
+      "ru": "Предметы вокруг: базовые фразы и практика.",
+      "en": "Objects Around You: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Предметы вокруг"
+  },
+  {
+    "lessonRef": "a0.basics.009",
+    "title": {
+      "ru": "Глагол to be: I am",
+      "en": "Verb to be: I am"
+    },
+    "description": {
+      "ru": "Глагол to be: I am: базовые фразы и практика.",
+      "en": "Verb to be: I am: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Глагол to be: I am"
+  },
+  {
+    "lessonRef": "a0.basics.010",
+    "title": {
+      "ru": "Глагол to be: you are",
+      "en": "Verb to be: you are"
+    },
+    "description": {
+      "ru": "Глагол to be: you are: базовые фразы и практика.",
+      "en": "Verb to be: you are: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Глагол to be: you are"
+  },
+  {
+    "lessonRef": "a0.basics.011",
+    "title": {
+      "ru": "Местоимения I/you/we",
+      "en": "Pronouns I/you/we"
+    },
+    "description": {
+      "ru": "Местоимения I/you/we: базовые фразы и практика.",
+      "en": "Pronouns I/you/we: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Местоимения I/you/we"
+  },
+  {
+    "lessonRef": "a0.basics.012",
+    "title": {
+      "ru": "Простые команды",
+      "en": "Simple Commands"
+    },
+    "description": {
+      "ru": "Простые команды: базовые фразы и практика.",
+      "en": "Simple Commands: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Простые команды"
+  },
+  {
+    "lessonRef": "a0.basics.013",
+    "title": {
+      "ru": "Предлоги места",
+      "en": "Prepositions of Place"
+    },
+    "description": {
+      "ru": "Предлоги места: базовые фразы и практика.",
+      "en": "Prepositions of Place: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Предлоги места"
+  },
+  {
+    "lessonRef": "a0.basics.014",
+    "title": {
+      "ru": "Вопросы yes/no",
+      "en": "Yes/No Questions"
+    },
+    "description": {
+      "ru": "Вопросы yes/no: базовые фразы и практика.",
+      "en": "Yes/No Questions: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вопросы yes/no"
+  },
+  {
+    "lessonRef": "a0.basics.015",
+    "title": {
+      "ru": "Короткие диалоги",
+      "en": "Short Dialogues"
+    },
+    "description": {
+      "ru": "Короткие диалоги: базовые фразы и практика.",
+      "en": "Short Dialogues: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Короткие диалоги"
+  },
+  {
+    "lessonRef": "a0.basics.016",
+    "title": {
+      "ru": "Вежливые формулы",
+      "en": "Polite Phrases"
+    },
+    "description": {
+      "ru": "Вежливые формулы: базовые фразы и практика.",
+      "en": "Polite Phrases: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вежливые формулы"
+  },
+  {
+    "lessonRef": "a0.basics.017",
+    "title": {
+      "ru": "Повторение: базовые фразы",
+      "en": "Review: Basic Phrases"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы: базовые фразы и практика.",
+      "en": "Review: Basic Phrases: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение: базовые фразы"
+  },
+  {
+    "lessonRef": "a0.basics.018",
+    "title": {
+      "ru": "Мини-диалог: знакомство",
+      "en": "Mini Dialogue: Introductions"
+    },
+    "description": {
+      "ru": "Мини-диалог: знакомство: базовые фразы и практика.",
+      "en": "Mini Dialogue: Introductions: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-диалог: знакомство"
+  },
+  {
+    "lessonRef": "a0.basics.019",
+    "title": {
+      "ru": "Произношение трудных звуков",
+      "en": "Pronunciation of Tricky Sounds"
+    },
+    "description": {
+      "ru": "Произношение трудных звуков: базовые фразы и практика.",
+      "en": "Pronunciation of Tricky Sounds: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение трудных звуков"
+  },
+  {
+    "lessonRef": "a0.basics.020",
+    "title": {
+      "ru": "Итоговое повторение",
+      "en": "Final Review"
+    },
+    "description": {
+      "ru": "Итоговое повторение: базовые фразы и практика.",
+      "en": "Final Review: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "basics",
+      "communication",
+      "основы общения"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итоговое повторение"
+  }
+]

--- a/scripts/actual/content/A0/a0.cafe/lessons.json
+++ b/scripts/actual/content/A0/a0.cafe/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.cafe.001",
+    "title": {
+      "ru": "Приветствие в кафе",
+      "en": "Greeting in a Cafe"
+    },
+    "description": {
+      "ru": "Приветствие в кафе: базовые фразы и практика.",
+      "en": "Greeting in a Cafe: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Приветствие в кафе"
+  },
+  {
+    "lessonRef": "a0.cafe.002",
+    "title": {
+      "ru": "Столик на двоих",
+      "en": "Table for Two"
+    },
+    "description": {
+      "ru": "Столик на двоих: базовые фразы и практика.",
+      "en": "Table for Two: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Столик на двоих"
+  },
+  {
+    "lessonRef": "a0.cafe.003",
+    "title": {
+      "ru": "Меню и блюда",
+      "en": "Menu and Dishes"
+    },
+    "description": {
+      "ru": "Меню и блюда: базовые фразы и практика.",
+      "en": "Menu and Dishes: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Меню и блюда"
+  },
+  {
+    "lessonRef": "a0.cafe.004",
+    "title": {
+      "ru": "Напитки",
+      "en": "Drinks"
+    },
+    "description": {
+      "ru": "Напитки: базовые фразы и практика.",
+      "en": "Drinks: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Напитки"
+  },
+  {
+    "lessonRef": "a0.cafe.005",
+    "title": {
+      "ru": "Заказ",
+      "en": "Ordering"
+    },
+    "description": {
+      "ru": "Заказ: базовые фразы и практика.",
+      "en": "Ordering: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Заказ"
+  },
+  {
+    "lessonRef": "a0.cafe.006",
+    "title": {
+      "ru": "Пожелания к блюду",
+      "en": "Special Requests"
+    },
+    "description": {
+      "ru": "Пожелания к блюду: базовые фразы и практика.",
+      "en": "Special Requests: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Пожелания к блюду"
+  },
+  {
+    "lessonRef": "a0.cafe.007",
+    "title": {
+      "ru": "Счёт",
+      "en": "The Bill"
+    },
+    "description": {
+      "ru": "Счёт: базовые фразы и практика.",
+      "en": "The Bill: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Счёт"
+  },
+  {
+    "lessonRef": "a0.cafe.008",
+    "title": {
+      "ru": "Оплата",
+      "en": "Payment"
+    },
+    "description": {
+      "ru": "Оплата: базовые фразы и практика.",
+      "en": "Payment: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Оплата"
+  },
+  {
+    "lessonRef": "a0.cafe.009",
+    "title": {
+      "ru": "Чаевые",
+      "en": "Tips"
+    },
+    "description": {
+      "ru": "Чаевые: базовые фразы и практика.",
+      "en": "Tips: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Чаевые"
+  },
+  {
+    "lessonRef": "a0.cafe.010",
+    "title": {
+      "ru": "Жалоба",
+      "en": "Complaint"
+    },
+    "description": {
+      "ru": "Жалоба: базовые фразы и практика.",
+      "en": "Complaint: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Жалоба"
+  },
+  {
+    "lessonRef": "a0.cafe.011",
+    "title": {
+      "ru": "Благодарность",
+      "en": "Thanking"
+    },
+    "description": {
+      "ru": "Благодарность: базовые фразы и практика.",
+      "en": "Thanking: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Благодарность"
+  },
+  {
+    "lessonRef": "a0.cafe.012",
+    "title": {
+      "ru": "Диалог: быстрый заказ",
+      "en": "Dialogue: Quick Order"
+    },
+    "description": {
+      "ru": "Диалог: быстрый заказ: базовые фразы и практика.",
+      "en": "Dialogue: Quick Order: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: быстрый заказ"
+  },
+  {
+    "lessonRef": "a0.cafe.013",
+    "title": {
+      "ru": "Диалог: уточнение",
+      "en": "Dialogue: уточнение"
+    },
+    "description": {
+      "ru": "Диалог: уточнение: базовые фразы и практика.",
+      "en": "Dialogue: уточнение: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: уточнение"
+  },
+  {
+    "lessonRef": "a0.cafe.014",
+    "title": {
+      "ru": "Диалог: нет блюда",
+      "en": "Dialogue: Item Unavailable"
+    },
+    "description": {
+      "ru": "Диалог: нет блюда: базовые фразы и практика.",
+      "en": "Dialogue: Item Unavailable: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: нет блюда"
+  },
+  {
+    "lessonRef": "a0.cafe.015",
+    "title": {
+      "ru": "Произношение",
+      "en": "Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение: базовые фразы и практика.",
+      "en": "Pronunciation: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение"
+  },
+  {
+    "lessonRef": "a0.cafe.016",
+    "title": {
+      "ru": "Словарь кафе",
+      "en": "Cafe Vocabulary"
+    },
+    "description": {
+      "ru": "Словарь кафе: базовые фразы и практика.",
+      "en": "Cafe Vocabulary: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Словарь кафе"
+  },
+  {
+    "lessonRef": "a0.cafe.017",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.cafe.018",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.cafe.019",
+    "title": {
+      "ru": "Мини-ролевая игра",
+      "en": "Mini Role-play"
+    },
+    "description": {
+      "ru": "Мини-ролевая игра: базовые фразы и практика.",
+      "en": "Mini Role-play: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-ролевая игра"
+  },
+  {
+    "lessonRef": "a0.cafe.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "cafe",
+      "conversation",
+      "в кафе"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.colors/lessons.json
+++ b/scripts/actual/content/A0/a0.colors/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.colors.001",
+    "title": {
+      "ru": "Основные цвета",
+      "en": "Basic Colors"
+    },
+    "description": {
+      "ru": "Основные цвета: базовые фразы и практика.",
+      "en": "Basic Colors: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Основные цвета"
+  },
+  {
+    "lessonRef": "a0.colors.002",
+    "title": {
+      "ru": "Светлый/тёмный",
+      "en": "Light/Dark"
+    },
+    "description": {
+      "ru": "Светлый/тёмный: базовые фразы и практика.",
+      "en": "Light/Dark: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Светлый/тёмный"
+  },
+  {
+    "lessonRef": "a0.colors.003",
+    "title": {
+      "ru": "Яркие цвета",
+      "en": "Bright Colors"
+    },
+    "description": {
+      "ru": "Яркие цвета: базовые фразы и практика.",
+      "en": "Bright Colors: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Яркие цвета"
+  },
+  {
+    "lessonRef": "a0.colors.004",
+    "title": {
+      "ru": "Смешанные цвета",
+      "en": "Mixed Colors"
+    },
+    "description": {
+      "ru": "Смешанные цвета: базовые фразы и практика.",
+      "en": "Mixed Colors: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Смешанные цвета"
+  },
+  {
+    "lessonRef": "a0.colors.005",
+    "title": {
+      "ru": "Цвета предметов",
+      "en": "Colors of Objects"
+    },
+    "description": {
+      "ru": "Цвета предметов: базовые фразы и практика.",
+      "en": "Colors of Objects: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Цвета предметов"
+  },
+  {
+    "lessonRef": "a0.colors.006",
+    "title": {
+      "ru": "Одежда и цвета",
+      "en": "Clothes and Colors"
+    },
+    "description": {
+      "ru": "Одежда и цвета: базовые фразы и практика.",
+      "en": "Clothes and Colors: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Одежда и цвета"
+  },
+  {
+    "lessonRef": "a0.colors.007",
+    "title": {
+      "ru": "Животные и цвета",
+      "en": "Animals and Colors"
+    },
+    "description": {
+      "ru": "Животные и цвета: базовые фразы и практика.",
+      "en": "Animals and Colors: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Животные и цвета"
+  },
+  {
+    "lessonRef": "a0.colors.008",
+    "title": {
+      "ru": "Любимый цвет",
+      "en": "Favorite Color"
+    },
+    "description": {
+      "ru": "Любимый цвет: базовые фразы и практика.",
+      "en": "Favorite Color: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Любимый цвет"
+  },
+  {
+    "lessonRef": "a0.colors.009",
+    "title": {
+      "ru": "Прилагательные",
+      "en": "Adjectives"
+    },
+    "description": {
+      "ru": "Прилагательные: базовые фразы и практика.",
+      "en": "Adjectives: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Прилагательные"
+  },
+  {
+    "lessonRef": "a0.colors.010",
+    "title": {
+      "ru": "Большой/маленький",
+      "en": "Big/Small"
+    },
+    "description": {
+      "ru": "Большой/маленький: базовые фразы и практика.",
+      "en": "Big/Small: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Большой/маленький"
+  },
+  {
+    "lessonRef": "a0.colors.011",
+    "title": {
+      "ru": "Форма",
+      "en": "Shape"
+    },
+    "description": {
+      "ru": "Форма: базовые фразы и практика.",
+      "en": "Shape: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Форма"
+  },
+  {
+    "lessonRef": "a0.colors.012",
+    "title": {
+      "ru": "Описание комнаты",
+      "en": "Describing a Room"
+    },
+    "description": {
+      "ru": "Описание комнаты: базовые фразы и практика.",
+      "en": "Describing a Room: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Описание комнаты"
+  },
+  {
+    "lessonRef": "a0.colors.013",
+    "title": {
+      "ru": "Описание предмета",
+      "en": "Describing an Object"
+    },
+    "description": {
+      "ru": "Описание предмета: базовые фразы и практика.",
+      "en": "Describing an Object: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Описание предмета"
+  },
+  {
+    "lessonRef": "a0.colors.014",
+    "title": {
+      "ru": "Диалог в магазине",
+      "en": "Dialogue in a Store"
+    },
+    "description": {
+      "ru": "Диалог в магазине: базовые фразы и практика.",
+      "en": "Dialogue in a Store: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог в магазине"
+  },
+  {
+    "lessonRef": "a0.colors.015",
+    "title": {
+      "ru": "Произношение цветов",
+      "en": "Color Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение цветов: базовые фразы и практика.",
+      "en": "Color Pronunciation: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение цветов"
+  },
+  {
+    "lessonRef": "a0.colors.016",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.colors.017",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.colors.018",
+    "title": {
+      "ru": "Мини-описание",
+      "en": "Mini Description"
+    },
+    "description": {
+      "ru": "Мини-описание: базовые фразы и практика.",
+      "en": "Mini Description: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-описание"
+  },
+  {
+    "lessonRef": "a0.colors.019",
+    "title": {
+      "ru": "Игра: угадай цвет",
+      "en": "Game: Guess the Color"
+    },
+    "description": {
+      "ru": "Игра: угадай цвет: базовые фразы и практика.",
+      "en": "Game: Guess the Color: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Игра: угадай цвет"
+  },
+  {
+    "lessonRef": "a0.colors.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "colors",
+      "adjectives",
+      "цвета и описание"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.directions/lessons.json
+++ b/scripts/actual/content/A0/a0.directions/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.directions.001",
+    "title": {
+      "ru": "Где находится...?",
+      "en": "Where is...?"
+    },
+    "description": {
+      "ru": "Где находится...?: базовые фразы и практика.",
+      "en": "Where is...?: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Где находится...?"
+  },
+  {
+    "lessonRef": "a0.directions.002",
+    "title": {
+      "ru": "Поворот направо",
+      "en": "Turn Right"
+    },
+    "description": {
+      "ru": "Поворот направо: базовые фразы и практика.",
+      "en": "Turn Right: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Поворот направо"
+  },
+  {
+    "lessonRef": "a0.directions.003",
+    "title": {
+      "ru": "Поворот налево",
+      "en": "Turn Left"
+    },
+    "description": {
+      "ru": "Поворот налево: базовые фразы и практика.",
+      "en": "Turn Left: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Поворот налево"
+  },
+  {
+    "lessonRef": "a0.directions.004",
+    "title": {
+      "ru": "Прямо",
+      "en": "Go Straight"
+    },
+    "description": {
+      "ru": "Прямо: базовые фразы и практика.",
+      "en": "Go Straight: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Прямо"
+  },
+  {
+    "lessonRef": "a0.directions.005",
+    "title": {
+      "ru": "Рядом/далеко",
+      "en": "Near/Far"
+    },
+    "description": {
+      "ru": "Рядом/далеко: базовые фразы и практика.",
+      "en": "Near/Far: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Рядом/далеко"
+  },
+  {
+    "lessonRef": "a0.directions.006",
+    "title": {
+      "ru": "На углу",
+      "en": "On the Corner"
+    },
+    "description": {
+      "ru": "На углу: базовые фразы и практика.",
+      "en": "On the Corner: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "На углу"
+  },
+  {
+    "lessonRef": "a0.directions.007",
+    "title": {
+      "ru": "Перед/за",
+      "en": "In Front of/Behind"
+    },
+    "description": {
+      "ru": "Перед/за: базовые фразы и практика.",
+      "en": "In Front of/Behind: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Перед/за"
+  },
+  {
+    "lessonRef": "a0.directions.008",
+    "title": {
+      "ru": "Через дорогу",
+      "en": "Across the Street"
+    },
+    "description": {
+      "ru": "Через дорогу: базовые фразы и практика.",
+      "en": "Across the Street: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Через дорогу"
+  },
+  {
+    "lessonRef": "a0.directions.009",
+    "title": {
+      "ru": "Между",
+      "en": "Between"
+    },
+    "description": {
+      "ru": "Между: базовые фразы и практика.",
+      "en": "Between: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Между"
+  },
+  {
+    "lessonRef": "a0.directions.010",
+    "title": {
+      "ru": "Схема пути",
+      "en": "Route"
+    },
+    "description": {
+      "ru": "Схема пути: базовые фразы и практика.",
+      "en": "Route: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Схема пути"
+  },
+  {
+    "lessonRef": "a0.directions.011",
+    "title": {
+      "ru": "Остановки транспорта",
+      "en": "Transport Stops"
+    },
+    "description": {
+      "ru": "Остановки транспорта: базовые фразы и практика.",
+      "en": "Transport Stops: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Остановки транспорта"
+  },
+  {
+    "lessonRef": "a0.directions.012",
+    "title": {
+      "ru": "Диалог: спросить дорогу",
+      "en": "Dialogue: Asking for Directions"
+    },
+    "description": {
+      "ru": "Диалог: спросить дорогу: базовые фразы и практика.",
+      "en": "Dialogue: Asking for Directions: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: спросить дорогу"
+  },
+  {
+    "lessonRef": "a0.directions.013",
+    "title": {
+      "ru": "Диалог: объяснить путь",
+      "en": "Dialogue: Giving Directions"
+    },
+    "description": {
+      "ru": "Диалог: объяснить путь: базовые фразы и практика.",
+      "en": "Dialogue: Giving Directions: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: объяснить путь"
+  },
+  {
+    "lessonRef": "a0.directions.014",
+    "title": {
+      "ru": "Диалог: потерялся",
+      "en": "Dialogue: Lost"
+    },
+    "description": {
+      "ru": "Диалог: потерялся: базовые фразы и практика.",
+      "en": "Dialogue: Lost: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: потерялся"
+  },
+  {
+    "lessonRef": "a0.directions.015",
+    "title": {
+      "ru": "Словарь улицы",
+      "en": "Street Vocabulary"
+    },
+    "description": {
+      "ru": "Словарь улицы: базовые фразы и практика.",
+      "en": "Street Vocabulary: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Словарь улицы"
+  },
+  {
+    "lessonRef": "a0.directions.016",
+    "title": {
+      "ru": "Произношение",
+      "en": "Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение: базовые фразы и практика.",
+      "en": "Pronunciation: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение"
+  },
+  {
+    "lessonRef": "a0.directions.017",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.directions.018",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.directions.019",
+    "title": {
+      "ru": "Мини-карта",
+      "en": "Mini Map"
+    },
+    "description": {
+      "ru": "Мини-карта: базовые фразы и практика.",
+      "en": "Mini Map: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-карта"
+  },
+  {
+    "lessonRef": "a0.directions.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "directions",
+      "navigation",
+      "спросить дорогу"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.family/lessons.json
+++ b/scripts/actual/content/A0/a0.family/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.family.001",
+    "title": {
+      "ru": "Члены семьи",
+      "en": "Family Members"
+    },
+    "description": {
+      "ru": "Члены семьи: базовые фразы и практика.",
+      "en": "Family Members: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Члены семьи"
+  },
+  {
+    "lessonRef": "a0.family.002",
+    "title": {
+      "ru": "Мама/папа",
+      "en": "Mother/Father"
+    },
+    "description": {
+      "ru": "Мама/папа: базовые фразы и практика.",
+      "en": "Mother/Father: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мама/папа"
+  },
+  {
+    "lessonRef": "a0.family.003",
+    "title": {
+      "ru": "Брат/сестра",
+      "en": "Brother/Sister"
+    },
+    "description": {
+      "ru": "Брат/сестра: базовые фразы и практика.",
+      "en": "Brother/Sister: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Брат/сестра"
+  },
+  {
+    "lessonRef": "a0.family.004",
+    "title": {
+      "ru": "Бабушка/дедушка",
+      "en": "Grandparents"
+    },
+    "description": {
+      "ru": "Бабушка/дедушка: базовые фразы и практика.",
+      "en": "Grandparents: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Бабушка/дедушка"
+  },
+  {
+    "lessonRef": "a0.family.005",
+    "title": {
+      "ru": "Дети",
+      "en": "Children"
+    },
+    "description": {
+      "ru": "Дети: базовые фразы и практика.",
+      "en": "Children: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Дети"
+  },
+  {
+    "lessonRef": "a0.family.006",
+    "title": {
+      "ru": "Семейное древо",
+      "en": "Family Tree"
+    },
+    "description": {
+      "ru": "Семейное древо: базовые фразы и практика.",
+      "en": "Family Tree: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Семейное древо"
+  },
+  {
+    "lessonRef": "a0.family.007",
+    "title": {
+      "ru": "Возраст членов семьи",
+      "en": "Family Ages"
+    },
+    "description": {
+      "ru": "Возраст членов семьи: базовые фразы и практика.",
+      "en": "Family Ages: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Возраст членов семьи"
+  },
+  {
+    "lessonRef": "a0.family.008",
+    "title": {
+      "ru": "Профессии семьи",
+      "en": "Family Jobs"
+    },
+    "description": {
+      "ru": "Профессии семьи: базовые фразы и практика.",
+      "en": "Family Jobs: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Профессии семьи"
+  },
+  {
+    "lessonRef": "a0.family.009",
+    "title": {
+      "ru": "Хобби семьи",
+      "en": "Family Hobbies"
+    },
+    "description": {
+      "ru": "Хобби семьи: базовые фразы и практика.",
+      "en": "Family Hobbies: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Хобби семьи"
+  },
+  {
+    "lessonRef": "a0.family.010",
+    "title": {
+      "ru": "Мой дом",
+      "en": "My Home"
+    },
+    "description": {
+      "ru": "Мой дом: базовые фразы и практика.",
+      "en": "My Home: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мой дом"
+  },
+  {
+    "lessonRef": "a0.family.011",
+    "title": {
+      "ru": "Моя семья",
+      "en": "My Family"
+    },
+    "description": {
+      "ru": "Моя семья: базовые фразы и практика.",
+      "en": "My Family: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Моя семья"
+  },
+  {
+    "lessonRef": "a0.family.012",
+    "title": {
+      "ru": "Вопросы о семье",
+      "en": "Questions about Family"
+    },
+    "description": {
+      "ru": "Вопросы о семье: базовые фразы и практика.",
+      "en": "Questions about Family: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вопросы о семье"
+  },
+  {
+    "lessonRef": "a0.family.013",
+    "title": {
+      "ru": "Описание семьи",
+      "en": "Describing Family"
+    },
+    "description": {
+      "ru": "Описание семьи: базовые фразы и практика.",
+      "en": "Describing Family: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Описание семьи"
+  },
+  {
+    "lessonRef": "a0.family.014",
+    "title": {
+      "ru": "Фото семьи",
+      "en": "Family Photo"
+    },
+    "description": {
+      "ru": "Фото семьи: базовые фразы и практика.",
+      "en": "Family Photo: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Фото семьи"
+  },
+  {
+    "lessonRef": "a0.family.015",
+    "title": {
+      "ru": "Мини-диалог",
+      "en": "Mini Dialogue"
+    },
+    "description": {
+      "ru": "Мини-диалог: базовые фразы и практика.",
+      "en": "Mini Dialogue: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-диалог"
+  },
+  {
+    "lessonRef": "a0.family.016",
+    "title": {
+      "ru": "Произношение",
+      "en": "Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение: базовые фразы и практика.",
+      "en": "Pronunciation: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение"
+  },
+  {
+    "lessonRef": "a0.family.017",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.family.018",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.family.019",
+    "title": {
+      "ru": "Составь рассказ",
+      "en": "Make a Story"
+    },
+    "description": {
+      "ru": "Составь рассказ: базовые фразы и практика.",
+      "en": "Make a Story: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Составь рассказ"
+  },
+  {
+    "lessonRef": "a0.family.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "family",
+      "vocabulary",
+      "семья"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.food-drinks/lessons.json
+++ b/scripts/actual/content/A0/a0.food-drinks/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.food-drinks.001",
+    "title": {
+      "ru": "Фрукты",
+      "en": "Fruits"
+    },
+    "description": {
+      "ru": "Фрукты: базовые фразы и практика.",
+      "en": "Fruits: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Фрукты"
+  },
+  {
+    "lessonRef": "a0.food-drinks.002",
+    "title": {
+      "ru": "Овощи",
+      "en": "Vegetables"
+    },
+    "description": {
+      "ru": "Овощи: базовые фразы и практика.",
+      "en": "Vegetables: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Овощи"
+  },
+  {
+    "lessonRef": "a0.food-drinks.003",
+    "title": {
+      "ru": "Напитки",
+      "en": "Drinks"
+    },
+    "description": {
+      "ru": "Напитки: базовые фразы и практика.",
+      "en": "Drinks: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Напитки"
+  },
+  {
+    "lessonRef": "a0.food-drinks.004",
+    "title": {
+      "ru": "Завтрак",
+      "en": "Breakfast"
+    },
+    "description": {
+      "ru": "Завтрак: базовые фразы и практика.",
+      "en": "Breakfast: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Завтрак"
+  },
+  {
+    "lessonRef": "a0.food-drinks.005",
+    "title": {
+      "ru": "Обед",
+      "en": "Lunch"
+    },
+    "description": {
+      "ru": "Обед: базовые фразы и практика.",
+      "en": "Lunch: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Обед"
+  },
+  {
+    "lessonRef": "a0.food-drinks.006",
+    "title": {
+      "ru": "Ужин",
+      "en": "Dinner"
+    },
+    "description": {
+      "ru": "Ужин: базовые фразы и практика.",
+      "en": "Dinner: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Ужин"
+  },
+  {
+    "lessonRef": "a0.food-drinks.007",
+    "title": {
+      "ru": "Меню",
+      "en": "Menu"
+    },
+    "description": {
+      "ru": "Меню: базовые фразы и практика.",
+      "en": "Menu: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Меню"
+  },
+  {
+    "lessonRef": "a0.food-drinks.008",
+    "title": {
+      "ru": "Мне нравится",
+      "en": "I like"
+    },
+    "description": {
+      "ru": "Мне нравится: базовые фразы и практика.",
+      "en": "I like: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мне нравится"
+  },
+  {
+    "lessonRef": "a0.food-drinks.009",
+    "title": {
+      "ru": "Мне не нравится",
+      "en": "I don't like"
+    },
+    "description": {
+      "ru": "Мне не нравится: базовые фразы и практика.",
+      "en": "I don't like: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мне не нравится"
+  },
+  {
+    "lessonRef": "a0.food-drinks.010",
+    "title": {
+      "ru": "Аллергии",
+      "en": "Allergies"
+    },
+    "description": {
+      "ru": "Аллергии: базовые фразы и практика.",
+      "en": "Allergies: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Аллергии"
+  },
+  {
+    "lessonRef": "a0.food-drinks.011",
+    "title": {
+      "ru": "Сколько стоит?",
+      "en": "How much is it?"
+    },
+    "description": {
+      "ru": "Сколько стоит?: базовые фразы и практика.",
+      "en": "How much is it?: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Сколько стоит?"
+  },
+  {
+    "lessonRef": "a0.food-drinks.012",
+    "title": {
+      "ru": "Заказ в кафе",
+      "en": "Order in a Cafe"
+    },
+    "description": {
+      "ru": "Заказ в кафе: базовые фразы и практика.",
+      "en": "Order in a Cafe: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Заказ в кафе"
+  },
+  {
+    "lessonRef": "a0.food-drinks.013",
+    "title": {
+      "ru": "Просьбы",
+      "en": "Requests"
+    },
+    "description": {
+      "ru": "Просьбы: базовые фразы и практика.",
+      "en": "Requests: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Просьбы"
+  },
+  {
+    "lessonRef": "a0.food-drinks.014",
+    "title": {
+      "ru": "Диалог: в магазине",
+      "en": "Dialogue: In a Store"
+    },
+    "description": {
+      "ru": "Диалог: в магазине: базовые фразы и практика.",
+      "en": "Dialogue: In a Store: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: в магазине"
+  },
+  {
+    "lessonRef": "a0.food-drinks.015",
+    "title": {
+      "ru": "Диалог: в кафе",
+      "en": "Dialogue: In a Cafe"
+    },
+    "description": {
+      "ru": "Диалог: в кафе: базовые фразы и практика.",
+      "en": "Dialogue: In a Cafe: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: в кафе"
+  },
+  {
+    "lessonRef": "a0.food-drinks.016",
+    "title": {
+      "ru": "Произношение",
+      "en": "Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение: базовые фразы и практика.",
+      "en": "Pronunciation: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение"
+  },
+  {
+    "lessonRef": "a0.food-drinks.017",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.food-drinks.018",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.food-drinks.019",
+    "title": {
+      "ru": "Мини-меню",
+      "en": "Mini Menu"
+    },
+    "description": {
+      "ru": "Мини-меню: базовые фразы и практика.",
+      "en": "Mini Menu: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-меню"
+  },
+  {
+    "lessonRef": "a0.food-drinks.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "food",
+      "drinks",
+      "еда и напитки"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.greetings/lessons.json
+++ b/scripts/actual/content/A0/a0.greetings/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.greetings.001",
+    "title": {
+      "ru": "Hello и Hi: когда что",
+      "en": "Hello vs Hi"
+    },
+    "description": {
+      "ru": "Hello и Hi: когда что: базовые фразы и практика.",
+      "en": "Hello vs Hi: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Hello и Hi: когда что"
+  },
+  {
+    "lessonRef": "a0.greetings.002",
+    "title": {
+      "ru": "Good morning/afternoon/evening",
+      "en": "Good morning/afternoon/evening"
+    },
+    "description": {
+      "ru": "Good morning/afternoon/evening: базовые фразы и практика.",
+      "en": "Good morning/afternoon/evening: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Good morning/afternoon/evening"
+  },
+  {
+    "lessonRef": "a0.greetings.003",
+    "title": {
+      "ru": "Формальные приветствия",
+      "en": "Formal Greetings"
+    },
+    "description": {
+      "ru": "Формальные приветствия: базовые фразы и практика.",
+      "en": "Formal Greetings: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Формальные приветствия"
+  },
+  {
+    "lessonRef": "a0.greetings.004",
+    "title": {
+      "ru": "Неформальные приветствия",
+      "en": "Informal Greetings"
+    },
+    "description": {
+      "ru": "Неформальные приветствия: базовые фразы и практика.",
+      "en": "Informal Greetings: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Неформальные приветствия"
+  },
+  {
+    "lessonRef": "a0.greetings.005",
+    "title": {
+      "ru": "How are you? базовые ответы",
+      "en": "How are you? Basic Answers"
+    },
+    "description": {
+      "ru": "How are you? базовые ответы: базовые фразы и практика.",
+      "en": "How are you? Basic Answers: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "How are you? базовые ответы"
+  },
+  {
+    "lessonRef": "a0.greetings.006",
+    "title": {
+      "ru": "Nice to meet you",
+      "en": "Nice to meet you"
+    },
+    "description": {
+      "ru": "Nice to meet you: базовые фразы и практика.",
+      "en": "Nice to meet you: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Nice to meet you"
+  },
+  {
+    "lessonRef": "a0.greetings.007",
+    "title": {
+      "ru": "Представление себя",
+      "en": "Introducing Yourself"
+    },
+    "description": {
+      "ru": "Представление себя: базовые фразы и практика.",
+      "en": "Introducing Yourself: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Представление себя"
+  },
+  {
+    "lessonRef": "a0.greetings.008",
+    "title": {
+      "ru": "Представление другого",
+      "en": "Introducing Someone"
+    },
+    "description": {
+      "ru": "Представление другого: базовые фразы и практика.",
+      "en": "Introducing Someone: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Представление другого"
+  },
+  {
+    "lessonRef": "a0.greetings.009",
+    "title": {
+      "ru": "Small talk: погода",
+      "en": "Small Talk: Weather"
+    },
+    "description": {
+      "ru": "Small talk: погода: базовые фразы и практика.",
+      "en": "Small Talk: Weather: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Small talk: погода"
+  },
+  {
+    "lessonRef": "a0.greetings.010",
+    "title": {
+      "ru": "Small talk: время",
+      "en": "Small Talk: Time"
+    },
+    "description": {
+      "ru": "Small talk: время: базовые фразы и практика.",
+      "en": "Small Talk: Time: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Small talk: время"
+  },
+  {
+    "lessonRef": "a0.greetings.011",
+    "title": {
+      "ru": "Goodbye: See you/Take care",
+      "en": "Goodbye: See you/Take care"
+    },
+    "description": {
+      "ru": "Goodbye: See you/Take care: базовые фразы и практика.",
+      "en": "Goodbye: See you/Take care: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Goodbye: See you/Take care"
+  },
+  {
+    "lessonRef": "a0.greetings.012",
+    "title": {
+      "ru": "Прощания по телефону",
+      "en": "Goodbye on the Phone"
+    },
+    "description": {
+      "ru": "Прощания по телефону: базовые фразы и практика.",
+      "en": "Goodbye on the Phone: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Прощания по телефону"
+  },
+  {
+    "lessonRef": "a0.greetings.013",
+    "title": {
+      "ru": "Вежливые обращения",
+      "en": "Polite Address"
+    },
+    "description": {
+      "ru": "Вежливые обращения: базовые фразы и практика.",
+      "en": "Polite Address: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вежливые обращения"
+  },
+  {
+    "lessonRef": "a0.greetings.014",
+    "title": {
+      "ru": "Тренировка интонации",
+      "en": "Intonation Practice"
+    },
+    "description": {
+      "ru": "Тренировка интонации: базовые фразы и практика.",
+      "en": "Intonation Practice: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Тренировка интонации"
+  },
+  {
+    "lessonRef": "a0.greetings.015",
+    "title": {
+      "ru": "Диалог в магазине",
+      "en": "Dialogue in a Shop"
+    },
+    "description": {
+      "ru": "Диалог в магазине: базовые фразы и практика.",
+      "en": "Dialogue in a Shop: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог в магазине"
+  },
+  {
+    "lessonRef": "a0.greetings.016",
+    "title": {
+      "ru": "Диалог в кафе",
+      "en": "Dialogue in a Cafe"
+    },
+    "description": {
+      "ru": "Диалог в кафе: базовые фразы и практика.",
+      "en": "Dialogue in a Cafe: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог в кафе"
+  },
+  {
+    "lessonRef": "a0.greetings.017",
+    "title": {
+      "ru": "Диалог на улице",
+      "en": "Dialogue in the Street"
+    },
+    "description": {
+      "ru": "Диалог на улице: базовые фразы и практика.",
+      "en": "Dialogue in the Street: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог на улице"
+  },
+  {
+    "lessonRef": "a0.greetings.018",
+    "title": {
+      "ru": "Повторение: приветствия",
+      "en": "Review: Greetings"
+    },
+    "description": {
+      "ru": "Повторение: приветствия: базовые фразы и практика.",
+      "en": "Review: Greetings: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение: приветствия"
+  },
+  {
+    "lessonRef": "a0.greetings.019",
+    "title": {
+      "ru": "Повторение: прощания",
+      "en": "Review: Goodbyes"
+    },
+    "description": {
+      "ru": "Повторение: прощания: базовые фразы и практика.",
+      "en": "Review: Goodbyes: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение: прощания"
+  },
+  {
+    "lessonRef": "a0.greetings.020",
+    "title": {
+      "ru": "Итоговый диалог",
+      "en": "Final Dialogue"
+    },
+    "description": {
+      "ru": "Итоговый диалог: базовые фразы и практика.",
+      "en": "Final Dialogue: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "greetings",
+      "conversation",
+      "приветствия и прощания"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итоговый диалог"
+  }
+]

--- a/scripts/actual/content/A0/a0.howareyou/lessons.json
+++ b/scripts/actual/content/A0/a0.howareyou/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.howareyou.001",
+    "title": {
+      "ru": "How are you?",
+      "en": "How are you?"
+    },
+    "description": {
+      "ru": "How are you?: базовые фразы и практика.",
+      "en": "How are you?: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "How are you?"
+  },
+  {
+    "lessonRef": "a0.howareyou.002",
+    "title": {
+      "ru": "I am fine",
+      "en": "I am fine"
+    },
+    "description": {
+      "ru": "I am fine: базовые фразы и практика.",
+      "en": "I am fine: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "I am fine"
+  },
+  {
+    "lessonRef": "a0.howareyou.003",
+    "title": {
+      "ru": "I am good/bad",
+      "en": "I am good/bad"
+    },
+    "description": {
+      "ru": "I am good/bad: базовые фразы и практика.",
+      "en": "I am good/bad: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "I am good/bad"
+  },
+  {
+    "lessonRef": "a0.howareyou.004",
+    "title": {
+      "ru": "Так себе: not so good",
+      "en": "Not so good"
+    },
+    "description": {
+      "ru": "Так себе: not so good: базовые фразы и практика.",
+      "en": "Not so good: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Так себе: not so good"
+  },
+  {
+    "lessonRef": "a0.howareyou.005",
+    "title": {
+      "ru": "Состояние здоровья",
+      "en": "Health"
+    },
+    "description": {
+      "ru": "Состояние здоровья: базовые фразы и практика.",
+      "en": "Health: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Состояние здоровья"
+  },
+  {
+    "lessonRef": "a0.howareyou.006",
+    "title": {
+      "ru": "Эмоции: happy/sad",
+      "en": "Feelings: happy/sad"
+    },
+    "description": {
+      "ru": "Эмоции: happy/sad: базовые фразы и практика.",
+      "en": "Feelings: happy/sad: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Эмоции: happy/sad"
+  },
+  {
+    "lessonRef": "a0.howareyou.007",
+    "title": {
+      "ru": "Устал/занят",
+      "en": "Tired/Busy"
+    },
+    "description": {
+      "ru": "Устал/занят: базовые фразы и практика.",
+      "en": "Tired/Busy: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Устал/занят"
+  },
+  {
+    "lessonRef": "a0.howareyou.008",
+    "title": {
+      "ru": "Очень хорошо",
+      "en": "Very well"
+    },
+    "description": {
+      "ru": "Очень хорошо: базовые фразы и практика.",
+      "en": "Very well: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Очень хорошо"
+  },
+  {
+    "lessonRef": "a0.howareyou.009",
+    "title": {
+      "ru": "Реакции: really?",
+      "en": "Reactions: really?"
+    },
+    "description": {
+      "ru": "Реакции: really?: базовые фразы и практика.",
+      "en": "Reactions: really?: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Реакции: really?"
+  },
+  {
+    "lessonRef": "a0.howareyou.010",
+    "title": {
+      "ru": "А ты?",
+      "en": "And you?"
+    },
+    "description": {
+      "ru": "А ты?: базовые фразы и практика.",
+      "en": "And you?: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "А ты?"
+  },
+  {
+    "lessonRef": "a0.howareyou.011",
+    "title": {
+      "ru": "Вопросы о самочувствии",
+      "en": "Asking About Well-being"
+    },
+    "description": {
+      "ru": "Вопросы о самочувствии: базовые фразы и практика.",
+      "en": "Asking About Well-being: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вопросы о самочувствии"
+  },
+  {
+    "lessonRef": "a0.howareyou.012",
+    "title": {
+      "ru": "Ответы по времени",
+      "en": "Time-based Answers"
+    },
+    "description": {
+      "ru": "Ответы по времени: базовые фразы и практика.",
+      "en": "Time-based Answers: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Ответы по времени"
+  },
+  {
+    "lessonRef": "a0.howareyou.013",
+    "title": {
+      "ru": "Диалог: коллеги",
+      "en": "Dialogue: Colleagues"
+    },
+    "description": {
+      "ru": "Диалог: коллеги: базовые фразы и практика.",
+      "en": "Dialogue: Colleagues: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: коллеги"
+  },
+  {
+    "lessonRef": "a0.howareyou.014",
+    "title": {
+      "ru": "Диалог: друзья",
+      "en": "Dialogue: Friends"
+    },
+    "description": {
+      "ru": "Диалог: друзья: базовые фразы и практика.",
+      "en": "Dialogue: Friends: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: друзья"
+  },
+  {
+    "lessonRef": "a0.howareyou.015",
+    "title": {
+      "ru": "Диалог: по телефону",
+      "en": "Dialogue: Phone"
+    },
+    "description": {
+      "ru": "Диалог: по телефону: базовые фразы и практика.",
+      "en": "Dialogue: Phone: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: по телефону"
+  },
+  {
+    "lessonRef": "a0.howareyou.016",
+    "title": {
+      "ru": "Мини-отчёт о дне",
+      "en": "Mini Daily Report"
+    },
+    "description": {
+      "ru": "Мини-отчёт о дне: базовые фразы и практика.",
+      "en": "Mini Daily Report: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-отчёт о дне"
+  },
+  {
+    "lessonRef": "a0.howareyou.017",
+    "title": {
+      "ru": "Словарь эмоций",
+      "en": "Feelings Vocabulary"
+    },
+    "description": {
+      "ru": "Словарь эмоций: базовые фразы и практика.",
+      "en": "Feelings Vocabulary: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Словарь эмоций"
+  },
+  {
+    "lessonRef": "a0.howareyou.018",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.howareyou.019",
+    "title": {
+      "ru": "Практика интонации",
+      "en": "Intonation Practice"
+    },
+    "description": {
+      "ru": "Практика интонации: базовые фразы и практика.",
+      "en": "Intonation Practice: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика интонации"
+  },
+  {
+    "lessonRef": "a0.howareyou.020",
+    "title": {
+      "ru": "Итог: как дела",
+      "en": "Final: How are you"
+    },
+    "description": {
+      "ru": "Итог: как дела: базовые фразы и практика.",
+      "en": "Final: How are you: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "feelings",
+      "conversation",
+      "как дела"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог: как дела"
+  }
+]

--- a/scripts/actual/content/A0/a0.introductions/lessons.json
+++ b/scripts/actual/content/A0/a0.introductions/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.introductions.001",
+    "title": {
+      "ru": "My name is...",
+      "en": "My name is..."
+    },
+    "description": {
+      "ru": "My name is...: базовые фразы и практика.",
+      "en": "My name is...: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "My name is..."
+  },
+  {
+    "lessonRef": "a0.introductions.002",
+    "title": {
+      "ru": "What is your name?",
+      "en": "What is your name?"
+    },
+    "description": {
+      "ru": "What is your name?: базовые фразы и практика.",
+      "en": "What is your name?: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "What is your name?"
+  },
+  {
+    "lessonRef": "a0.introductions.003",
+    "title": {
+      "ru": "Откуда ты?",
+      "en": "Where are you from?"
+    },
+    "description": {
+      "ru": "Откуда ты?: базовые фразы и практика.",
+      "en": "Where are you from?: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Откуда ты?"
+  },
+  {
+    "lessonRef": "a0.introductions.004",
+    "title": {
+      "ru": "Страна и город",
+      "en": "Country and City"
+    },
+    "description": {
+      "ru": "Страна и город: базовые фразы и практика.",
+      "en": "Country and City: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Страна и город"
+  },
+  {
+    "lessonRef": "a0.introductions.005",
+    "title": {
+      "ru": "Национальности",
+      "en": "Nationalities"
+    },
+    "description": {
+      "ru": "Национальности: базовые фразы и практика.",
+      "en": "Nationalities: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Национальности"
+  },
+  {
+    "lessonRef": "a0.introductions.006",
+    "title": {
+      "ru": "Языки",
+      "en": "Languages"
+    },
+    "description": {
+      "ru": "Языки: базовые фразы и практика.",
+      "en": "Languages: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Языки"
+  },
+  {
+    "lessonRef": "a0.introductions.007",
+    "title": {
+      "ru": "Возраст",
+      "en": "Age"
+    },
+    "description": {
+      "ru": "Возраст: базовые фразы и практика.",
+      "en": "Age: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Возраст"
+  },
+  {
+    "lessonRef": "a0.introductions.008",
+    "title": {
+      "ru": "Профессия",
+      "en": "Occupation"
+    },
+    "description": {
+      "ru": "Профессия: базовые фразы и практика.",
+      "en": "Occupation: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Профессия"
+  },
+  {
+    "lessonRef": "a0.introductions.009",
+    "title": {
+      "ru": "Семейное положение",
+      "en": "Marital Status"
+    },
+    "description": {
+      "ru": "Семейное положение: базовые фразы и практика.",
+      "en": "Marital Status: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Семейное положение"
+  },
+  {
+    "lessonRef": "a0.introductions.010",
+    "title": {
+      "ru": "Хобби",
+      "en": "Hobbies"
+    },
+    "description": {
+      "ru": "Хобби: базовые фразы и практика.",
+      "en": "Hobbies: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Хобби"
+  },
+  {
+    "lessonRef": "a0.introductions.011",
+    "title": {
+      "ru": "Любимые вещи",
+      "en": "Favorite Things"
+    },
+    "description": {
+      "ru": "Любимые вещи: базовые фразы и практика.",
+      "en": "Favorite Things: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Любимые вещи"
+  },
+  {
+    "lessonRef": "a0.introductions.012",
+    "title": {
+      "ru": "Tell me about you",
+      "en": "Tell me about you"
+    },
+    "description": {
+      "ru": "Tell me about you: базовые фразы и практика.",
+      "en": "Tell me about you: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Tell me about you"
+  },
+  {
+    "lessonRef": "a0.introductions.013",
+    "title": {
+      "ru": "Короткие анкеты",
+      "en": "Short Forms"
+    },
+    "description": {
+      "ru": "Короткие анкеты: базовые фразы и практика.",
+      "en": "Short Forms: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Короткие анкеты"
+  },
+  {
+    "lessonRef": "a0.introductions.014",
+    "title": {
+      "ru": "Вежливые вопросы",
+      "en": "Polite Questions"
+    },
+    "description": {
+      "ru": "Вежливые вопросы: базовые фразы и практика.",
+      "en": "Polite Questions: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вежливые вопросы"
+  },
+  {
+    "lessonRef": "a0.introductions.015",
+    "title": {
+      "ru": "Диалог: первое знакомство",
+      "en": "Dialogue: First Meeting"
+    },
+    "description": {
+      "ru": "Диалог: первое знакомство: базовые фразы и практика.",
+      "en": "Dialogue: First Meeting: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: первое знакомство"
+  },
+  {
+    "lessonRef": "a0.introductions.016",
+    "title": {
+      "ru": "Диалог: коллеги",
+      "en": "Dialogue: Colleagues"
+    },
+    "description": {
+      "ru": "Диалог: коллеги: базовые фразы и практика.",
+      "en": "Dialogue: Colleagues: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: коллеги"
+  },
+  {
+    "lessonRef": "a0.introductions.017",
+    "title": {
+      "ru": "Диалог: соседи",
+      "en": "Dialogue: Neighbors"
+    },
+    "description": {
+      "ru": "Диалог: соседи: базовые фразы и практика.",
+      "en": "Dialogue: Neighbors: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: соседи"
+  },
+  {
+    "lessonRef": "a0.introductions.018",
+    "title": {
+      "ru": "Повторение ключевых фраз",
+      "en": "Review: Key Phrases"
+    },
+    "description": {
+      "ru": "Повторение ключевых фраз: базовые фразы и практика.",
+      "en": "Review: Key Phrases: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение ключевых фраз"
+  },
+  {
+    "lessonRef": "a0.introductions.019",
+    "title": {
+      "ru": "Произношение имён",
+      "en": "Name Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение имён: базовые фразы и практика.",
+      "en": "Name Pronunciation: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение имён"
+  },
+  {
+    "lessonRef": "a0.introductions.020",
+    "title": {
+      "ru": "Итог: познакомьтесь",
+      "en": "Final: Introduce Yourself"
+    },
+    "description": {
+      "ru": "Итог: познакомьтесь: базовые фразы и практика.",
+      "en": "Final: Introduce Yourself: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "introductions",
+      "conversation",
+      "знакомство"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог: познакомьтесь"
+  }
+]

--- a/scripts/actual/content/A0/a0.numbers/lessons.json
+++ b/scripts/actual/content/A0/a0.numbers/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.numbers.001",
+    "title": {
+      "ru": "Числа 1–5",
+      "en": "Numbers 1–5"
+    },
+    "description": {
+      "ru": "Числа 1–5: базовые фразы и практика.",
+      "en": "Numbers 1–5: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Числа 1–5"
+  },
+  {
+    "lessonRef": "a0.numbers.002",
+    "title": {
+      "ru": "Числа 6–10",
+      "en": "Numbers 6–10"
+    },
+    "description": {
+      "ru": "Числа 6–10: базовые фразы и практика.",
+      "en": "Numbers 6–10: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Числа 6–10"
+  },
+  {
+    "lessonRef": "a0.numbers.003",
+    "title": {
+      "ru": "Числа 11–15",
+      "en": "Numbers 11–15"
+    },
+    "description": {
+      "ru": "Числа 11–15: базовые фразы и практика.",
+      "en": "Numbers 11–15: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Числа 11–15"
+  },
+  {
+    "lessonRef": "a0.numbers.004",
+    "title": {
+      "ru": "Числа 16–20",
+      "en": "Numbers 16–20"
+    },
+    "description": {
+      "ru": "Числа 16–20: базовые фразы и практика.",
+      "en": "Numbers 16–20: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Числа 16–20"
+  },
+  {
+    "lessonRef": "a0.numbers.005",
+    "title": {
+      "ru": "Счёт предметов",
+      "en": "Counting Objects"
+    },
+    "description": {
+      "ru": "Счёт предметов: базовые фразы и практика.",
+      "en": "Counting Objects: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Счёт предметов"
+  },
+  {
+    "lessonRef": "a0.numbers.006",
+    "title": {
+      "ru": "Телефон",
+      "en": "Phone Number"
+    },
+    "description": {
+      "ru": "Телефон: базовые фразы и практика.",
+      "en": "Phone Number: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Телефон"
+  },
+  {
+    "lessonRef": "a0.numbers.007",
+    "title": {
+      "ru": "Возраст",
+      "en": "Age"
+    },
+    "description": {
+      "ru": "Возраст: базовые фразы и практика.",
+      "en": "Age: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Возраст"
+  },
+  {
+    "lessonRef": "a0.numbers.008",
+    "title": {
+      "ru": "Время: часы",
+      "en": "Time: Hours"
+    },
+    "description": {
+      "ru": "Время: часы: базовые фразы и практика.",
+      "en": "Time: Hours: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Время: часы"
+  },
+  {
+    "lessonRef": "a0.numbers.009",
+    "title": {
+      "ru": "Цена",
+      "en": "Price"
+    },
+    "description": {
+      "ru": "Цена: базовые фразы и практика.",
+      "en": "Price: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Цена"
+  },
+  {
+    "lessonRef": "a0.numbers.010",
+    "title": {
+      "ru": "Количество",
+      "en": "Quantity"
+    },
+    "description": {
+      "ru": "Количество: базовые фразы и практика.",
+      "en": "Quantity: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Количество"
+  },
+  {
+    "lessonRef": "a0.numbers.011",
+    "title": {
+      "ru": "Сколько это?",
+      "en": "How much is it?"
+    },
+    "description": {
+      "ru": "Сколько это?: базовые фразы и практика.",
+      "en": "How much is it?: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Сколько это?"
+  },
+  {
+    "lessonRef": "a0.numbers.012",
+    "title": {
+      "ru": "Сколько у тебя?",
+      "en": "How many do you have?"
+    },
+    "description": {
+      "ru": "Сколько у тебя?: базовые фразы и практика.",
+      "en": "How many do you have?: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Сколько у тебя?"
+  },
+  {
+    "lessonRef": "a0.numbers.013",
+    "title": {
+      "ru": "Диалог: покупка",
+      "en": "Dialogue: Purchase"
+    },
+    "description": {
+      "ru": "Диалог: покупка: базовые фразы и практика.",
+      "en": "Dialogue: Purchase: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: покупка"
+  },
+  {
+    "lessonRef": "a0.numbers.014",
+    "title": {
+      "ru": "Диалог: бронирование",
+      "en": "Dialogue: Booking"
+    },
+    "description": {
+      "ru": "Диалог: бронирование: базовые фразы и практика.",
+      "en": "Dialogue: Booking: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: бронирование"
+  },
+  {
+    "lessonRef": "a0.numbers.015",
+    "title": {
+      "ru": "Произношение чисел",
+      "en": "Number Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение чисел: базовые фразы и практика.",
+      "en": "Number Pronunciation: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение чисел"
+  },
+  {
+    "lessonRef": "a0.numbers.016",
+    "title": {
+      "ru": "Сложение",
+      "en": "Simple Addition"
+    },
+    "description": {
+      "ru": "Сложение: базовые фразы и практика.",
+      "en": "Simple Addition: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Сложение"
+  },
+  {
+    "lessonRef": "a0.numbers.017",
+    "title": {
+      "ru": "Вычитание",
+      "en": "Simple Subtraction"
+    },
+    "description": {
+      "ru": "Вычитание: базовые фразы и практика.",
+      "en": "Simple Subtraction: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вычитание"
+  },
+  {
+    "lessonRef": "a0.numbers.018",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.numbers.019",
+    "title": {
+      "ru": "Практика на слух",
+      "en": "Listening Practice"
+    },
+    "description": {
+      "ru": "Практика на слух: базовые фразы и практика.",
+      "en": "Listening Practice: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика на слух"
+  },
+  {
+    "lessonRef": "a0.numbers.020",
+    "title": {
+      "ru": "Итоговый тест",
+      "en": "Final Quiz"
+    },
+    "description": {
+      "ru": "Итоговый тест: базовые фразы и практика.",
+      "en": "Final Quiz: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "numbers",
+      "vocabulary",
+      "числа 1–20"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итоговый тест"
+  }
+]

--- a/scripts/actual/content/A0/a0.objects/lessons.json
+++ b/scripts/actual/content/A0/a0.objects/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.objects.001",
+    "title": {
+      "ru": "В комнате",
+      "en": "In the Room"
+    },
+    "description": {
+      "ru": "В комнате: базовые фразы и практика.",
+      "en": "In the Room: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В комнате"
+  },
+  {
+    "lessonRef": "a0.objects.002",
+    "title": {
+      "ru": "На кухне",
+      "en": "In the Kitchen"
+    },
+    "description": {
+      "ru": "На кухне: базовые фразы и практика.",
+      "en": "In the Kitchen: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "На кухне"
+  },
+  {
+    "lessonRef": "a0.objects.003",
+    "title": {
+      "ru": "В ванной",
+      "en": "In the Bathroom"
+    },
+    "description": {
+      "ru": "В ванной: базовые фразы и практика.",
+      "en": "In the Bathroom: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В ванной"
+  },
+  {
+    "lessonRef": "a0.objects.004",
+    "title": {
+      "ru": "В офисе",
+      "en": "In the Office"
+    },
+    "description": {
+      "ru": "В офисе: базовые фразы и практика.",
+      "en": "In the Office: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В офисе"
+  },
+  {
+    "lessonRef": "a0.objects.005",
+    "title": {
+      "ru": "В классе",
+      "en": "In the Classroom"
+    },
+    "description": {
+      "ru": "В классе: базовые фразы и практика.",
+      "en": "In the Classroom: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В классе"
+  },
+  {
+    "lessonRef": "a0.objects.006",
+    "title": {
+      "ru": "В сумке",
+      "en": "In the Bag"
+    },
+    "description": {
+      "ru": "В сумке: базовые фразы и практика.",
+      "en": "In the Bag: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В сумке"
+  },
+  {
+    "lessonRef": "a0.objects.007",
+    "title": {
+      "ru": "На улице",
+      "en": "Outside"
+    },
+    "description": {
+      "ru": "На улице: базовые фразы и практика.",
+      "en": "Outside: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "На улице"
+  },
+  {
+    "lessonRef": "a0.objects.008",
+    "title": {
+      "ru": "Покупки",
+      "en": "Shopping Items"
+    },
+    "description": {
+      "ru": "Покупки: базовые фразы и практика.",
+      "en": "Shopping Items: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Покупки"
+  },
+  {
+    "lessonRef": "a0.objects.009",
+    "title": {
+      "ru": "Считаем предметы",
+      "en": "Counting Objects"
+    },
+    "description": {
+      "ru": "Считаем предметы: базовые фразы и практика.",
+      "en": "Counting Objects: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Считаем предметы"
+  },
+  {
+    "lessonRef": "a0.objects.010",
+    "title": {
+      "ru": "Этот/тот",
+      "en": "This/That"
+    },
+    "description": {
+      "ru": "Этот/тот: базовые фразы и практика.",
+      "en": "This/That: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Этот/тот"
+  },
+  {
+    "lessonRef": "a0.objects.011",
+    "title": {
+      "ru": "Где находится?",
+      "en": "Where is it?"
+    },
+    "description": {
+      "ru": "Где находится?: базовые фразы и практика.",
+      "en": "Where is it?: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Где находится?"
+  },
+  {
+    "lessonRef": "a0.objects.012",
+    "title": {
+      "ru": "Описание предмета",
+      "en": "Describing an Object"
+    },
+    "description": {
+      "ru": "Описание предмета: базовые фразы и практика.",
+      "en": "Describing an Object: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Описание предмета"
+  },
+  {
+    "lessonRef": "a0.objects.013",
+    "title": {
+      "ru": "Предлоги места",
+      "en": "Prepositions of Place"
+    },
+    "description": {
+      "ru": "Предлоги места: базовые фразы и практика.",
+      "en": "Prepositions of Place: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Предлоги места"
+  },
+  {
+    "lessonRef": "a0.objects.014",
+    "title": {
+      "ru": "Диалог: найти вещь",
+      "en": "Dialogue: Finding an Item"
+    },
+    "description": {
+      "ru": "Диалог: найти вещь: базовые фразы и практика.",
+      "en": "Dialogue: Finding an Item: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: найти вещь"
+  },
+  {
+    "lessonRef": "a0.objects.015",
+    "title": {
+      "ru": "Диалог: попросить",
+      "en": "Dialogue: Asking for It"
+    },
+    "description": {
+      "ru": "Диалог: попросить: базовые фразы и практика.",
+      "en": "Dialogue: Asking for It: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: попросить"
+  },
+  {
+    "lessonRef": "a0.objects.016",
+    "title": {
+      "ru": "Произношение",
+      "en": "Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение: базовые фразы и практика.",
+      "en": "Pronunciation: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение"
+  },
+  {
+    "lessonRef": "a0.objects.017",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.objects.018",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.objects.019",
+    "title": {
+      "ru": "Мини-квест",
+      "en": "Mini Quest"
+    },
+    "description": {
+      "ru": "Мини-квест: базовые фразы и практика.",
+      "en": "Mini Quest: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-квест"
+  },
+  {
+    "lessonRef": "a0.objects.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "objects",
+      "vocabulary",
+      "вещи вокруг"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.polite/lessons.json
+++ b/scripts/actual/content/A0/a0.polite/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.polite.001",
+    "title": {
+      "ru": "Please и thank you",
+      "en": "Please and Thank You"
+    },
+    "description": {
+      "ru": "Please и thank you: базовые фразы и практика.",
+      "en": "Please and Thank You: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Please и thank you"
+  },
+  {
+    "lessonRef": "a0.polite.002",
+    "title": {
+      "ru": "Sorry и excuse me",
+      "en": "Sorry and Excuse me"
+    },
+    "description": {
+      "ru": "Sorry и excuse me: базовые фразы и практика.",
+      "en": "Sorry and Excuse me: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Sorry и excuse me"
+  },
+  {
+    "lessonRef": "a0.polite.003",
+    "title": {
+      "ru": "Could you...?",
+      "en": "Could you...?"
+    },
+    "description": {
+      "ru": "Could you...?: базовые фразы и практика.",
+      "en": "Could you...?: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Could you...?"
+  },
+  {
+    "lessonRef": "a0.polite.004",
+    "title": {
+      "ru": "Can you...?",
+      "en": "Can you...?"
+    },
+    "description": {
+      "ru": "Can you...?: базовые фразы и практика.",
+      "en": "Can you...?: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Can you...?"
+  },
+  {
+    "lessonRef": "a0.polite.005",
+    "title": {
+      "ru": "May I...?",
+      "en": "May I...?"
+    },
+    "description": {
+      "ru": "May I...?: базовые фразы и практика.",
+      "en": "May I...?: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "May I...?"
+  },
+  {
+    "lessonRef": "a0.polite.006",
+    "title": {
+      "ru": "Would you like...?",
+      "en": "Would you like...?"
+    },
+    "description": {
+      "ru": "Would you like...?: базовые фразы и практика.",
+      "en": "Would you like...?: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Would you like...?"
+  },
+  {
+    "lessonRef": "a0.polite.007",
+    "title": {
+      "ru": "Вот/пожалуйста",
+      "en": "Here you are"
+    },
+    "description": {
+      "ru": "Вот/пожалуйста: базовые фразы и практика.",
+      "en": "Here you are: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вот/пожалуйста"
+  },
+  {
+    "lessonRef": "a0.polite.008",
+    "title": {
+      "ru": "Извинения",
+      "en": "Apologies"
+    },
+    "description": {
+      "ru": "Извинения: базовые фразы и практика.",
+      "en": "Apologies: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Извинения"
+  },
+  {
+    "lessonRef": "a0.polite.009",
+    "title": {
+      "ru": "Просьбы в магазине",
+      "en": "Requests in a Shop"
+    },
+    "description": {
+      "ru": "Просьбы в магазине: базовые фразы и практика.",
+      "en": "Requests in a Shop: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Просьбы в магазине"
+  },
+  {
+    "lessonRef": "a0.polite.010",
+    "title": {
+      "ru": "Просьбы в кафе",
+      "en": "Requests in a Cafe"
+    },
+    "description": {
+      "ru": "Просьбы в кафе: базовые фразы и практика.",
+      "en": "Requests in a Cafe: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Просьбы в кафе"
+  },
+  {
+    "lessonRef": "a0.polite.011",
+    "title": {
+      "ru": "Просьбы на улице",
+      "en": "Requests in the Street"
+    },
+    "description": {
+      "ru": "Просьбы на улице: базовые фразы и практика.",
+      "en": "Requests in the Street: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Просьбы на улице"
+  },
+  {
+    "lessonRef": "a0.polite.012",
+    "title": {
+      "ru": "Вежливые ответы",
+      "en": "Polite Responses"
+    },
+    "description": {
+      "ru": "Вежливые ответы: базовые фразы и практика.",
+      "en": "Polite Responses: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Вежливые ответы"
+  },
+  {
+    "lessonRef": "a0.polite.013",
+    "title": {
+      "ru": "Благодарность",
+      "en": "Gratitude"
+    },
+    "description": {
+      "ru": "Благодарность: базовые фразы и практика.",
+      "en": "Gratitude: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Благодарность"
+  },
+  {
+    "lessonRef": "a0.polite.014",
+    "title": {
+      "ru": "Отказ вежливо",
+      "en": "Polite Refusal"
+    },
+    "description": {
+      "ru": "Отказ вежливо: базовые фразы и практика.",
+      "en": "Polite Refusal: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Отказ вежливо"
+  },
+  {
+    "lessonRef": "a0.polite.015",
+    "title": {
+      "ru": "Формальная речь",
+      "en": "Formal Speech"
+    },
+    "description": {
+      "ru": "Формальная речь: базовые фразы и практика.",
+      "en": "Formal Speech: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Формальная речь"
+  },
+  {
+    "lessonRef": "a0.polite.016",
+    "title": {
+      "ru": "Неформальная речь",
+      "en": "Informal Speech"
+    },
+    "description": {
+      "ru": "Неформальная речь: базовые фразы и практика.",
+      "en": "Informal Speech: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Неформальная речь"
+  },
+  {
+    "lessonRef": "a0.polite.017",
+    "title": {
+      "ru": "Диалог: просьба помощи",
+      "en": "Dialogue: Asking for Help"
+    },
+    "description": {
+      "ru": "Диалог: просьба помощи: базовые фразы и практика.",
+      "en": "Dialogue: Asking for Help: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: просьба помощи"
+  },
+  {
+    "lessonRef": "a0.polite.018",
+    "title": {
+      "ru": "Диалог: благодарность",
+      "en": "Dialogue: Saying Thanks"
+    },
+    "description": {
+      "ru": "Диалог: благодарность: базовые фразы и практика.",
+      "en": "Dialogue: Saying Thanks: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: благодарность"
+  },
+  {
+    "lessonRef": "a0.polite.019",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.polite.020",
+    "title": {
+      "ru": "Итоговый сценарий",
+      "en": "Final Scenario"
+    },
+    "description": {
+      "ru": "Итоговый сценарий: базовые фразы и практика.",
+      "en": "Final Scenario: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "polite",
+      "phrases",
+      "вежливые слова"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итоговый сценарий"
+  }
+]

--- a/scripts/actual/content/A0/a0.pronouns/lessons.json
+++ b/scripts/actual/content/A0/a0.pronouns/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.pronouns.001",
+    "title": {
+      "ru": "I/you/he/she",
+      "en": "I/you/he/she"
+    },
+    "description": {
+      "ru": "I/you/he/she: базовые фразы и практика.",
+      "en": "I/you/he/she: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "I/you/he/she"
+  },
+  {
+    "lessonRef": "a0.pronouns.002",
+    "title": {
+      "ru": "We/they",
+      "en": "We/they"
+    },
+    "description": {
+      "ru": "We/they: базовые фразы и практика.",
+      "en": "We/they: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "We/they"
+  },
+  {
+    "lessonRef": "a0.pronouns.003",
+    "title": {
+      "ru": "My/your",
+      "en": "My/your"
+    },
+    "description": {
+      "ru": "My/your: базовые фразы и практика.",
+      "en": "My/your: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "My/your"
+  },
+  {
+    "lessonRef": "a0.pronouns.004",
+    "title": {
+      "ru": "His/her",
+      "en": "His/her"
+    },
+    "description": {
+      "ru": "His/her: базовые фразы и практика.",
+      "en": "His/her: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "His/her"
+  },
+  {
+    "lessonRef": "a0.pronouns.005",
+    "title": {
+      "ru": "Our/their",
+      "en": "Our/their"
+    },
+    "description": {
+      "ru": "Our/their: базовые фразы и практика.",
+      "en": "Our/their: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Our/their"
+  },
+  {
+    "lessonRef": "a0.pronouns.006",
+    "title": {
+      "ru": "This/that",
+      "en": "This/that"
+    },
+    "description": {
+      "ru": "This/that: базовые фразы и практика.",
+      "en": "This/that: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "This/that"
+  },
+  {
+    "lessonRef": "a0.pronouns.007",
+    "title": {
+      "ru": "These/those",
+      "en": "These/those"
+    },
+    "description": {
+      "ru": "These/those: базовые фразы и практика.",
+      "en": "These/those: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "These/those"
+  },
+  {
+    "lessonRef": "a0.pronouns.008",
+    "title": {
+      "ru": "Кто?",
+      "en": "Who?"
+    },
+    "description": {
+      "ru": "Кто?: базовые фразы и практика.",
+      "en": "Who?: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Кто?"
+  },
+  {
+    "lessonRef": "a0.pronouns.009",
+    "title": {
+      "ru": "Что?",
+      "en": "What?"
+    },
+    "description": {
+      "ru": "Что?: базовые фразы и практика.",
+      "en": "What?: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Что?"
+  },
+  {
+    "lessonRef": "a0.pronouns.010",
+    "title": {
+      "ru": "Указательные местоимения",
+      "en": "Demonstratives"
+    },
+    "description": {
+      "ru": "Указательные местоимения: базовые фразы и практика.",
+      "en": "Demonstratives: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Указательные местоимения"
+  },
+  {
+    "lessonRef": "a0.pronouns.011",
+    "title": {
+      "ru": "Местоимения в диалоге",
+      "en": "Pronouns in Dialogue"
+    },
+    "description": {
+      "ru": "Местоимения в диалоге: базовые фразы и практика.",
+      "en": "Pronouns in Dialogue: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Местоимения в диалоге"
+  },
+  {
+    "lessonRef": "a0.pronouns.012",
+    "title": {
+      "ru": "Семья и местоимения",
+      "en": "Family and Pronouns"
+    },
+    "description": {
+      "ru": "Семья и местоимения: базовые фразы и практика.",
+      "en": "Family and Pronouns: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Семья и местоимения"
+  },
+  {
+    "lessonRef": "a0.pronouns.013",
+    "title": {
+      "ru": "Мои вещи",
+      "en": "My Things"
+    },
+    "description": {
+      "ru": "Мои вещи: базовые фразы и практика.",
+      "en": "My Things: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мои вещи"
+  },
+  {
+    "lessonRef": "a0.pronouns.014",
+    "title": {
+      "ru": "Твои вещи",
+      "en": "Your Things"
+    },
+    "description": {
+      "ru": "Твои вещи: базовые фразы и практика.",
+      "en": "Your Things: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Твои вещи"
+  },
+  {
+    "lessonRef": "a0.pronouns.015",
+    "title": {
+      "ru": "Его/её вещи",
+      "en": "His/Her Things"
+    },
+    "description": {
+      "ru": "Его/её вещи: базовые фразы и практика.",
+      "en": "His/Her Things: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Его/её вещи"
+  },
+  {
+    "lessonRef": "a0.pronouns.016",
+    "title": {
+      "ru": "Мини-истории",
+      "en": "Mini Stories"
+    },
+    "description": {
+      "ru": "Мини-истории: базовые фразы и практика.",
+      "en": "Mini Stories: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-истории"
+  },
+  {
+    "lessonRef": "a0.pronouns.017",
+    "title": {
+      "ru": "Частые ошибки",
+      "en": "Common Mistakes"
+    },
+    "description": {
+      "ru": "Частые ошибки: базовые фразы и практика.",
+      "en": "Common Mistakes: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Частые ошибки"
+  },
+  {
+    "lessonRef": "a0.pronouns.018",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.pronouns.019",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.pronouns.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "pronouns",
+      "grammar",
+      "местоимения и притяжательные"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.shopping/lessons.json
+++ b/scripts/actual/content/A0/a0.shopping/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.shopping.001",
+    "title": {
+      "ru": "Магазин: приветствие",
+      "en": "Shopping: Greeting"
+    },
+    "description": {
+      "ru": "Магазин: приветствие: базовые фразы и практика.",
+      "en": "Shopping: Greeting: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Магазин: приветствие"
+  },
+  {
+    "lessonRef": "a0.shopping.002",
+    "title": {
+      "ru": "Поиск товара",
+      "en": "Finding an Item"
+    },
+    "description": {
+      "ru": "Поиск товара: базовые фразы и практика.",
+      "en": "Finding an Item: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Поиск товара"
+  },
+  {
+    "lessonRef": "a0.shopping.003",
+    "title": {
+      "ru": "Размеры",
+      "en": "Sizes"
+    },
+    "description": {
+      "ru": "Размеры: базовые фразы и практика.",
+      "en": "Sizes: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Размеры"
+  },
+  {
+    "lessonRef": "a0.shopping.004",
+    "title": {
+      "ru": "Цвета в покупках",
+      "en": "Colors in Shopping"
+    },
+    "description": {
+      "ru": "Цвета в покупках: базовые фразы и практика.",
+      "en": "Colors in Shopping: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Цвета в покупках"
+  },
+  {
+    "lessonRef": "a0.shopping.005",
+    "title": {
+      "ru": "Сколько стоит?",
+      "en": "How much is it?"
+    },
+    "description": {
+      "ru": "Сколько стоит?: базовые фразы и практика.",
+      "en": "How much is it?: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Сколько стоит?"
+  },
+  {
+    "lessonRef": "a0.shopping.006",
+    "title": {
+      "ru": "Скидка",
+      "en": "Discount"
+    },
+    "description": {
+      "ru": "Скидка: базовые фразы и практика.",
+      "en": "Discount: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Скидка"
+  },
+  {
+    "lessonRef": "a0.shopping.007",
+    "title": {
+      "ru": "Примерка",
+      "en": "Fitting"
+    },
+    "description": {
+      "ru": "Примерка: базовые фразы и практика.",
+      "en": "Fitting: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Примерка"
+  },
+  {
+    "lessonRef": "a0.shopping.008",
+    "title": {
+      "ru": "Касса",
+      "en": "Checkout"
+    },
+    "description": {
+      "ru": "Касса: базовые фразы и практика.",
+      "en": "Checkout: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Касса"
+  },
+  {
+    "lessonRef": "a0.shopping.009",
+    "title": {
+      "ru": "Оплата картой",
+      "en": "Paying by Card"
+    },
+    "description": {
+      "ru": "Оплата картой: базовые фразы и практика.",
+      "en": "Paying by Card: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Оплата картой"
+  },
+  {
+    "lessonRef": "a0.shopping.010",
+    "title": {
+      "ru": "Возврат",
+      "en": "Return"
+    },
+    "description": {
+      "ru": "Возврат: базовые фразы и практика.",
+      "en": "Return: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Возврат"
+  },
+  {
+    "lessonRef": "a0.shopping.011",
+    "title": {
+      "ru": "Диалог: покупка одежды",
+      "en": "Dialogue: Buying Clothes"
+    },
+    "description": {
+      "ru": "Диалог: покупка одежды: базовые фразы и практика.",
+      "en": "Dialogue: Buying Clothes: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: покупка одежды"
+  },
+  {
+    "lessonRef": "a0.shopping.012",
+    "title": {
+      "ru": "Диалог: сувениры",
+      "en": "Dialogue: Souvenirs"
+    },
+    "description": {
+      "ru": "Диалог: сувениры: базовые фразы и практика.",
+      "en": "Dialogue: Souvenirs: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: сувениры"
+  },
+  {
+    "lessonRef": "a0.shopping.013",
+    "title": {
+      "ru": "Диалог: цена",
+      "en": "Dialogue: Price"
+    },
+    "description": {
+      "ru": "Диалог: цена: базовые фразы и практика.",
+      "en": "Dialogue: Price: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: цена"
+  },
+  {
+    "lessonRef": "a0.shopping.014",
+    "title": {
+      "ru": "Произношение",
+      "en": "Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение: базовые фразы и практика.",
+      "en": "Pronunciation: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение"
+  },
+  {
+    "lessonRef": "a0.shopping.015",
+    "title": {
+      "ru": "Словарь покупок",
+      "en": "Shopping Vocabulary"
+    },
+    "description": {
+      "ru": "Словарь покупок: базовые фразы и практика.",
+      "en": "Shopping Vocabulary: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Словарь покупок"
+  },
+  {
+    "lessonRef": "a0.shopping.016",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.shopping.017",
+    "title": {
+      "ru": "Практика",
+      "en": "Practice"
+    },
+    "description": {
+      "ru": "Практика: базовые фразы и практика.",
+      "en": "Practice: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Практика"
+  },
+  {
+    "lessonRef": "a0.shopping.018",
+    "title": {
+      "ru": "Мини-список покупок",
+      "en": "Mini Shopping List"
+    },
+    "description": {
+      "ru": "Мини-список покупок: базовые фразы и практика.",
+      "en": "Mini Shopping List: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-список покупок"
+  },
+  {
+    "lessonRef": "a0.shopping.019",
+    "title": {
+      "ru": "Ролевая игра",
+      "en": "Role-play"
+    },
+    "description": {
+      "ru": "Ролевая игра: базовые фразы и практика.",
+      "en": "Role-play: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Ролевая игра"
+  },
+  {
+    "lessonRef": "a0.shopping.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "shopping",
+      "prices",
+      "покупки и цена"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.time-days/lessons.json
+++ b/scripts/actual/content/A0/a0.time-days/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.time-days.001",
+    "title": {
+      "ru": "What time is it?",
+      "en": "What time is it?"
+    },
+    "description": {
+      "ru": "What time is it?: базовые фразы и практика.",
+      "en": "What time is it?: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "What time is it?"
+  },
+  {
+    "lessonRef": "a0.time-days.002",
+    "title": {
+      "ru": "Часы: o'clock",
+      "en": "Hours: o'clock"
+    },
+    "description": {
+      "ru": "Часы: o'clock: базовые фразы и практика.",
+      "en": "Hours: o'clock: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Часы: o'clock"
+  },
+  {
+    "lessonRef": "a0.time-days.003",
+    "title": {
+      "ru": "Минуты: quarter/half",
+      "en": "Minutes: quarter/half"
+    },
+    "description": {
+      "ru": "Минуты: quarter/half: базовые фразы и практика.",
+      "en": "Minutes: quarter/half: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Минуты: quarter/half"
+  },
+  {
+    "lessonRef": "a0.time-days.004",
+    "title": {
+      "ru": "AM/PM",
+      "en": "AM/PM"
+    },
+    "description": {
+      "ru": "AM/PM: базовые фразы и практика.",
+      "en": "AM/PM: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "AM/PM"
+  },
+  {
+    "lessonRef": "a0.time-days.005",
+    "title": {
+      "ru": "Дни недели",
+      "en": "Days of the Week"
+    },
+    "description": {
+      "ru": "Дни недели: базовые фразы и практика.",
+      "en": "Days of the Week: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Дни недели"
+  },
+  {
+    "lessonRef": "a0.time-days.006",
+    "title": {
+      "ru": "Сегодня/завтра/вчера",
+      "en": "Today/Tomorrow/Yesterday"
+    },
+    "description": {
+      "ru": "Сегодня/завтра/вчера: базовые фразы и практика.",
+      "en": "Today/Tomorrow/Yesterday: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Сегодня/завтра/вчера"
+  },
+  {
+    "lessonRef": "a0.time-days.007",
+    "title": {
+      "ru": "Утро/день/вечер/ночь",
+      "en": "Morning/Afternoon/Evening/Night"
+    },
+    "description": {
+      "ru": "Утро/день/вечер/ночь: базовые фразы и практика.",
+      "en": "Morning/Afternoon/Evening/Night: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Утро/день/вечер/ночь"
+  },
+  {
+    "lessonRef": "a0.time-days.008",
+    "title": {
+      "ru": "Расписание",
+      "en": "Schedule"
+    },
+    "description": {
+      "ru": "Расписание: базовые фразы и практика.",
+      "en": "Schedule: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Расписание"
+  },
+  {
+    "lessonRef": "a0.time-days.009",
+    "title": {
+      "ru": "Когда?",
+      "en": "When?"
+    },
+    "description": {
+      "ru": "Когда?: базовые фразы и практика.",
+      "en": "When?: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Когда?"
+  },
+  {
+    "lessonRef": "a0.time-days.010",
+    "title": {
+      "ru": "В какое время?",
+      "en": "At what time?"
+    },
+    "description": {
+      "ru": "В какое время?: базовые фразы и практика.",
+      "en": "At what time?: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В какое время?"
+  },
+  {
+    "lessonRef": "a0.time-days.011",
+    "title": {
+      "ru": "Частотность: always/never",
+      "en": "Frequency: always/never"
+    },
+    "description": {
+      "ru": "Частотность: always/never: базовые фразы и практика.",
+      "en": "Frequency: always/never: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Частотность: always/never"
+  },
+  {
+    "lessonRef": "a0.time-days.012",
+    "title": {
+      "ru": "Частотность: usually/sometimes",
+      "en": "Frequency: usually/sometimes"
+    },
+    "description": {
+      "ru": "Частотность: usually/sometimes: базовые фразы и практика.",
+      "en": "Frequency: usually/sometimes: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Частотность: usually/sometimes"
+  },
+  {
+    "lessonRef": "a0.time-days.013",
+    "title": {
+      "ru": "Диалог: встреча",
+      "en": "Dialogue: Meeting"
+    },
+    "description": {
+      "ru": "Диалог: встреча: базовые фразы и практика.",
+      "en": "Dialogue: Meeting: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: встреча"
+  },
+  {
+    "lessonRef": "a0.time-days.014",
+    "title": {
+      "ru": "Диалог: рабочий день",
+      "en": "Dialogue: Workday"
+    },
+    "description": {
+      "ru": "Диалог: рабочий день: базовые фразы и практика.",
+      "en": "Dialogue: Workday: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: рабочий день"
+  },
+  {
+    "lessonRef": "a0.time-days.015",
+    "title": {
+      "ru": "Диалог: планы",
+      "en": "Dialogue: Plans"
+    },
+    "description": {
+      "ru": "Диалог: планы: базовые фразы и практика.",
+      "en": "Dialogue: Plans: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: планы"
+  },
+  {
+    "lessonRef": "a0.time-days.016",
+    "title": {
+      "ru": "Произношение времени",
+      "en": "Time Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение времени: базовые фразы и практика.",
+      "en": "Time Pronunciation: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение времени"
+  },
+  {
+    "lessonRef": "a0.time-days.017",
+    "title": {
+      "ru": "Повторение дней",
+      "en": "Review: Days"
+    },
+    "description": {
+      "ru": "Повторение дней: базовые фразы и практика.",
+      "en": "Review: Days: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение дней"
+  },
+  {
+    "lessonRef": "a0.time-days.018",
+    "title": {
+      "ru": "Повторение времени",
+      "en": "Review: Time"
+    },
+    "description": {
+      "ru": "Повторение времени: базовые фразы и практика.",
+      "en": "Review: Time: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение времени"
+  },
+  {
+    "lessonRef": "a0.time-days.019",
+    "title": {
+      "ru": "Мини-расписание",
+      "en": "Mini Schedule"
+    },
+    "description": {
+      "ru": "Мини-расписание: базовые фразы и практика.",
+      "en": "Mini Schedule: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Мини-расписание"
+  },
+  {
+    "lessonRef": "a0.time-days.020",
+    "title": {
+      "ru": "Итог",
+      "en": "Final Review"
+    },
+    "description": {
+      "ru": "Итог: базовые фразы и практика.",
+      "en": "Final Review: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "time",
+      "days",
+      "время и дни"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог"
+  }
+]

--- a/scripts/actual/content/A0/a0.travel/lessons.json
+++ b/scripts/actual/content/A0/a0.travel/lessons.json
@@ -1,0 +1,482 @@
+[
+  {
+    "lessonRef": "a0.travel.001",
+    "title": {
+      "ru": "В аэропорту",
+      "en": "At the Airport"
+    },
+    "description": {
+      "ru": "В аэропорту: базовые фразы и практика.",
+      "en": "At the Airport: basic phrases and practice."
+    },
+    "order": 1,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В аэропорту"
+  },
+  {
+    "lessonRef": "a0.travel.002",
+    "title": {
+      "ru": "Регистрация",
+      "en": "Check-in"
+    },
+    "description": {
+      "ru": "Регистрация: базовые фразы и практика.",
+      "en": "Check-in: basic phrases and practice."
+    },
+    "order": 2,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Регистрация"
+  },
+  {
+    "lessonRef": "a0.travel.003",
+    "title": {
+      "ru": "Паспорт и билет",
+      "en": "Passport and Ticket"
+    },
+    "description": {
+      "ru": "Паспорт и билет: базовые фразы и практика.",
+      "en": "Passport and Ticket: basic phrases and practice."
+    },
+    "order": 3,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Паспорт и билет"
+  },
+  {
+    "lessonRef": "a0.travel.004",
+    "title": {
+      "ru": "Посадка",
+      "en": "Boarding"
+    },
+    "description": {
+      "ru": "Посадка: базовые фразы и практика.",
+      "en": "Boarding: basic phrases and practice."
+    },
+    "order": 4,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Посадка"
+  },
+  {
+    "lessonRef": "a0.travel.005",
+    "title": {
+      "ru": "В самолёте",
+      "en": "On the Plane"
+    },
+    "description": {
+      "ru": "В самолёте: базовые фразы и практика.",
+      "en": "On the Plane: basic phrases and practice."
+    },
+    "order": 5,
+    "estimatedMinutes": 12,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В самолёте"
+  },
+  {
+    "lessonRef": "a0.travel.006",
+    "title": {
+      "ru": "Багаж",
+      "en": "Baggage"
+    },
+    "description": {
+      "ru": "Багаж: базовые фразы и практика.",
+      "en": "Baggage: basic phrases and practice."
+    },
+    "order": 6,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Багаж"
+  },
+  {
+    "lessonRef": "a0.travel.007",
+    "title": {
+      "ru": "В отеле",
+      "en": "At the Hotel"
+    },
+    "description": {
+      "ru": "В отеле: базовые фразы и практика.",
+      "en": "At the Hotel: basic phrases and practice."
+    },
+    "order": 7,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В отеле"
+  },
+  {
+    "lessonRef": "a0.travel.008",
+    "title": {
+      "ru": "Бронирование",
+      "en": "Reservation"
+    },
+    "description": {
+      "ru": "Бронирование: базовые фразы и практика.",
+      "en": "Reservation: basic phrases and practice."
+    },
+    "order": 8,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Бронирование"
+  },
+  {
+    "lessonRef": "a0.travel.009",
+    "title": {
+      "ru": "Заселение",
+      "en": "Check-in at Hotel"
+    },
+    "description": {
+      "ru": "Заселение: базовые фразы и практика.",
+      "en": "Check-in at Hotel: basic phrases and practice."
+    },
+    "order": 9,
+    "estimatedMinutes": 10,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Заселение"
+  },
+  {
+    "lessonRef": "a0.travel.010",
+    "title": {
+      "ru": "Номер",
+      "en": "The Room"
+    },
+    "description": {
+      "ru": "Номер: базовые фразы и практика.",
+      "en": "The Room: basic phrases and practice."
+    },
+    "order": 10,
+    "estimatedMinutes": 11,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 30,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Номер"
+  },
+  {
+    "lessonRef": "a0.travel.011",
+    "title": {
+      "ru": "В городе",
+      "en": "In the City"
+    },
+    "description": {
+      "ru": "В городе: базовые фразы и практика.",
+      "en": "In the City: basic phrases and practice."
+    },
+    "order": 11,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 20,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "В городе"
+  },
+  {
+    "lessonRef": "a0.travel.012",
+    "title": {
+      "ru": "Транспорт",
+      "en": "Transport"
+    },
+    "description": {
+      "ru": "Транспорт: базовые фразы и практика.",
+      "en": "Transport: basic phrases and practice."
+    },
+    "order": 12,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 21,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Транспорт"
+  },
+  {
+    "lessonRef": "a0.travel.013",
+    "title": {
+      "ru": "Такси",
+      "en": "Taxi"
+    },
+    "description": {
+      "ru": "Такси: базовые фразы и практика.",
+      "en": "Taxi: basic phrases and practice."
+    },
+    "order": 13,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 22,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Такси"
+  },
+  {
+    "lessonRef": "a0.travel.014",
+    "title": {
+      "ru": "Покупка билета",
+      "en": "Buying a Ticket"
+    },
+    "description": {
+      "ru": "Покупка билета: базовые фразы и практика.",
+      "en": "Buying a Ticket: basic phrases and practice."
+    },
+    "order": 14,
+    "estimatedMinutes": 9,
+    "type": "vocabulary",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 23,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Покупка билета"
+  },
+  {
+    "lessonRef": "a0.travel.015",
+    "title": {
+      "ru": "Обмен валюты",
+      "en": "Currency Exchange"
+    },
+    "description": {
+      "ru": "Обмен валюты: базовые фразы и практика.",
+      "en": "Currency Exchange: basic phrases and practice."
+    },
+    "order": 15,
+    "estimatedMinutes": 10,
+    "type": "conversation",
+    "difficulty": "easy",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 24,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Обмен валюты"
+  },
+  {
+    "lessonRef": "a0.travel.016",
+    "title": {
+      "ru": "Проблемы в пути",
+      "en": "Travel Problems"
+    },
+    "description": {
+      "ru": "Проблемы в пути: базовые фразы и практика.",
+      "en": "Travel Problems: basic phrases and practice."
+    },
+    "order": 16,
+    "estimatedMinutes": 11,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 25,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Проблемы в пути"
+  },
+  {
+    "lessonRef": "a0.travel.017",
+    "title": {
+      "ru": "Диалог: помощь",
+      "en": "Dialogue: Help"
+    },
+    "description": {
+      "ru": "Диалог: помощь: базовые фразы и практика.",
+      "en": "Dialogue: Help: basic phrases and practice."
+    },
+    "order": 17,
+    "estimatedMinutes": 12,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 26,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Диалог: помощь"
+  },
+  {
+    "lessonRef": "a0.travel.018",
+    "title": {
+      "ru": "Произношение",
+      "en": "Pronunciation"
+    },
+    "description": {
+      "ru": "Произношение: базовые фразы и практика.",
+      "en": "Pronunciation: basic phrases and practice."
+    },
+    "order": 18,
+    "estimatedMinutes": 7,
+    "type": "grammar",
+    "difficulty": "medium",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 27,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Произношение"
+  },
+  {
+    "lessonRef": "a0.travel.019",
+    "title": {
+      "ru": "Повторение",
+      "en": "Review"
+    },
+    "description": {
+      "ru": "Повторение: базовые фразы и практика.",
+      "en": "Review: basic phrases and practice."
+    },
+    "order": 19,
+    "estimatedMinutes": 8,
+    "type": "vocabulary",
+    "difficulty": "medium",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 28,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Повторение"
+  },
+  {
+    "lessonRef": "a0.travel.020",
+    "title": {
+      "ru": "Итог: мини-путешествие",
+      "en": "Final: Mini Trip"
+    },
+    "description": {
+      "ru": "Итог: мини-путешествие: базовые фразы и практика.",
+      "en": "Final: Mini Trip: basic phrases and practice."
+    },
+    "order": 20,
+    "estimatedMinutes": 9,
+    "type": "conversation",
+    "difficulty": "medium",
+    "tags": [
+      "travel",
+      "conversation",
+      "путешествия"
+    ],
+    "xpReward": 29,
+    "hasAudio": true,
+    "hasVideo": false,
+    "previewText": "Итог: мини-путешествие"
+  }
+]

--- a/scripts/actual/seed-lessons.ts
+++ b/scripts/actual/seed-lessons.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env ts-node
+import 'dotenv/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import mongoose from 'mongoose';
+
+import { Lesson, LessonSchema } from '../../src/modules/common/schemas/lesson.schema';
+import { MultilingualText, OptionalMultilingualText, validateMultilingualText } from '../../src/modules/common/utils/i18n.util';
+import { isValidLessonRef, matchesModuleRef } from '../../src/modules/common/utils/lesson-ref';
+
+const LEVELS = ['A0', 'A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const;
+type Level = typeof LEVELS[number];
+
+type LessonSeed = {
+  lessonRef: string;
+  moduleRef?: string;
+  title: MultilingualText;
+  description?: OptionalMultilingualText;
+  estimatedMinutes?: number;
+  order?: number;
+  published?: boolean;
+  requiresPro?: boolean;
+  type?: 'conversation' | 'vocabulary' | 'grammar';
+  difficulty?: 'easy' | 'medium' | 'hard';
+  tags?: string[];
+  xpReward?: number;
+  hasAudio?: boolean;
+  hasVideo?: boolean;
+  previewText?: string;
+};
+
+function normalizeLevelFromModuleRef(moduleRef: string): Level {
+  const rawLevel = moduleRef.split('.')[0]?.toUpperCase();
+  if (!LEVELS.includes(rawLevel as Level)) {
+    throw new Error(`Не удалось определить уровень из moduleRef: ${moduleRef}. Пример: a0.basics`);
+  }
+  return rawLevel as Level;
+}
+
+function resolveLessonsPath(level: Level, moduleRef: string): string {
+  return path.join(__dirname, 'content', level, moduleRef, 'lessons.json');
+}
+
+function readLessons(filePath: string): LessonSeed[] {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Файл не найден: ${filePath}`);
+  }
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error('Ожидался JSON-массив уроков');
+  }
+  return parsed as LessonSeed[];
+}
+
+function validateLessonSeed(seed: LessonSeed, moduleRef: string): string[] {
+  const errors: string[] = [];
+  if (!seed.lessonRef || !isValidLessonRef(seed.lessonRef)) {
+    errors.push(`Некорректный lessonRef: ${seed.lessonRef}`);
+  }
+  const seedModuleRef = seed.moduleRef ?? moduleRef;
+  if (!matchesModuleRef(seed.lessonRef, seedModuleRef)) {
+    errors.push(`lessonRef должен соответствовать moduleRef (${seedModuleRef}.NNN)`);
+  }
+  if (!seed.title || !validateMultilingualText(seed.title)) {
+    errors.push('title должен содержать переводы ru и en');
+  }
+  if (seed.description && !validateMultilingualText(seed.description, ['ru'])) {
+    errors.push('description должен содержать хотя бы ru, если указан');
+  }
+  if (seed.published === true) {
+    errors.push('published=true недопустим для сидера без задач');
+  }
+  return errors;
+}
+
+(async () => {
+  const moduleRef = process.argv[2];
+  if (!moduleRef) {
+    throw new Error('Укажите moduleRef. Пример: ts-node scripts/actual/seed-lessons.ts a0.basics');
+  }
+
+  const level = normalizeLevelFromModuleRef(moduleRef);
+  const filePath = resolveLessonsPath(level, moduleRef);
+
+  const lessons = readLessons(filePath);
+  if (!lessons.length) {
+    console.log('❗️Файл lessons.json пустой');
+    return;
+  }
+
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/burlive';
+  const dbName = process.env.MONGODB_DB_NAME || 'englishintg';
+
+  await mongoose.connect(uri, { dbName });
+  console.log(`🔗 MongoDB подключен (db: ${dbName})`);
+
+  const LessonModel = mongoose.model<Lesson>(Lesson.name, LessonSchema);
+
+  let successCount = 0;
+  let skippedCount = 0;
+
+  for (const lesson of lessons) {
+    const errors = validateLessonSeed(lesson, moduleRef);
+    if (errors.length) {
+      console.log(`⚠️ Пропуск ${lesson.lessonRef || '<без lessonRef>'}: ${errors.join('; ')}`);
+      skippedCount += 1;
+      continue;
+    }
+
+    const payload: Partial<Lesson> = {
+      lessonRef: lesson.lessonRef,
+      moduleRef,
+      title: lesson.title,
+      description: lesson.description,
+      estimatedMinutes: lesson.estimatedMinutes,
+      order: lesson.order,
+      published: lesson.published ?? false,
+      requiresPro: lesson.requiresPro,
+      type: lesson.type,
+      difficulty: lesson.difficulty,
+      tags: lesson.tags,
+      xpReward: lesson.xpReward,
+      hasAudio: lesson.hasAudio,
+      hasVideo: lesson.hasVideo,
+      previewText: lesson.previewText,
+    };
+
+    await LessonModel.updateOne(
+      { lessonRef: lesson.lessonRef },
+      { $set: payload },
+      { upsert: true },
+    );
+    successCount += 1;
+  }
+
+  console.log(`✅ Готово. Обработано: ${lessons.length}, успешно: ${successCount}, пропущено: ${skippedCount}`);
+  await mongoose.disconnect();
+})().catch(async error => {
+  console.error('❌ Ошибка сидера:', error instanceof Error ? error.message : error);
+  try {
+    await mongoose.disconnect();
+  } catch (disconnectError) {
+    console.error('⚠️ Не удалось корректно отключиться от MongoDB', disconnectError);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide ready-to-import lesson data for A0 modules with a thoughtful 20-lesson progression per module.  
- Make it easy to bulk-seed lessons without creating tasks or accidentally publishing content.  
- Store multilingual lesson metadata and platform-specific fields so the platform can use audio/video/XP/tags.  
- Allow idempotent, environment-driven seeding into MongoDB via a dedicated script.

### Description
- Added `scripts/actual/content/A0/*/lessons.json` (16 modules) with 20 lessons each containing `lessonRef`, multilingual `title`/`description`, `order`, `estimatedMinutes`, `type`, `difficulty`, `tags`, `xpReward`, `hasAudio`/`hasVideo`, and `previewText`.  
- Added `scripts/actual/seed-lessons.ts` which resolves the path by level, reads `lessons.json`, validates seeds with `isValidLessonRef`, `matchesModuleRef` and `validateMultilingualText`, forbids `published: true`, and performs safe upserts via Mongoose.  
- A small content generator was used to produce the JSON files following a seasoned-tutor plan (varied lesson types, difficulty progression, and timings).  
- The seeder connects using `MONGODB_URI` and `MONGODB_DB_NAME` and can be run as `ts-node scripts/actual/seed-lessons.ts a0.basics` for verification.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c42b82b88320a8f4a7c2041f0369)